### PR TITLE
글로벌 및 챗봇 에러코드 정의

### DIFF
--- a/chatbot/backend/src/main/java/com/hallachatbot/global/errorcode/ChatErrorCode.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/global/errorcode/ChatErrorCode.java
@@ -1,0 +1,48 @@
+package com.hallachatbot.global.errorcode;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ChatErrorCode implements ErrorCode {
+	// [500] AI 서비스 응답 오류
+	AI_SERVICE_ERROR(
+		INTERNAL_SERVER_ERROR,
+		"AI 응답 생성 중 오류가 발생했습니다.",
+		"AI 서비스가 에러 상태 코드를 반환"),
+
+	// [500] 스트리밍 데이터 파싱 실패
+	AI_RESPONSE_PARSING_FAILED(
+		INTERNAL_SERVER_ERROR,
+		"AI 응답 처리 중 오류가 발생했습니다.",
+		"AI 서비스로부터 받은 스트리밍 JSON 데이터 파싱 실패"),
+
+	// [500] 스트리밍 도중 끊김
+	STREAMING_INTERRUPTED(
+		INTERNAL_SERVER_ERROR,
+		"응답 스트리밍 중 연결이 끊겼습니다.",
+		"클라이언트 또는 AI 서비스와의 스트리밍 연결이 예기치 않게 종료됨"),
+
+	// [503] AI 서비스 연결 실패
+	AI_SERVICE_UNAVAILABLE(
+		SERVICE_UNAVAILABLE,
+		"챗봇 서버에 연결할 수 없습니다. 잠시 후 다시 시도해주세요.",
+		"AI 서비스 엔드포인트 연결 실패 또는 타임아웃 발생"),
+
+	// [400] 유효하지 않은 Chat ID
+	INVALID_CHAT_ID(
+		BAD_REQUEST,
+		"이전 대화 내역을 불러올 수 없습니다.",
+		"전달된 chatId가 유효한 ObjectId 형식이 아님");
+
+	private final HttpStatus status;
+	private final String message;
+	private final String logMessage;
+}

--- a/chatbot/backend/src/main/java/com/hallachatbot/global/errorcode/ErrorCode.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/global/errorcode/ErrorCode.java
@@ -1,0 +1,13 @@
+package com.hallachatbot.global.errorcode;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+	HttpStatus getStatus();
+
+	String getMessage();
+
+	String getLogMessage();
+
+	String name();
+}

--- a/chatbot/backend/src/main/java/com/hallachatbot/global/errorcode/GlobalErrorCode.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/global/errorcode/GlobalErrorCode.java
@@ -1,0 +1,76 @@
+package com.hallachatbot.global.errorcode;
+
+import static org.springframework.http.HttpStatus.*;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum GlobalErrorCode implements ErrorCode {
+	// [400] @Valid 검증 실패
+	INVALID_INPUT_VALUE(
+		BAD_REQUEST,
+		"입력값이 올바르지 않습니다",
+		"@Valid 검증 실패"),
+
+	// [400] 타입 불일치 (Request Param 등)
+	INVALID_TYPE_VALUE(
+		BAD_REQUEST,
+		"잘못된 타입이 포함되어 있습니다",
+		"요청 값 타입 불일치"),
+
+	// [400] JSON 형식 오류 또는 파싱 실패
+	INVALID_REQUEST_FORMAT(
+		BAD_REQUEST,
+		"요청 데이터 형식이 올바르지 않습니다",
+		"요청 데이터 형식 오류"),
+
+	// [400] 필수 쿼리 파라미터 누락
+	MISSING_REQUIRED_PARAMETER(
+		BAD_REQUEST,
+		"필수 요청 파라미터가 누락되었습니다",
+		"필수 쿼리 파라미터 누락"),
+
+	// [400] 필수 헤더 누락
+	MISSING_REQUIRED_HEADER(
+		BAD_REQUEST,
+		"필수 요청 헤더가 누락되었습니다",
+		"필수 요청 헤더 누락"),
+
+	// [404] 매핑된 핸들러가 없는 URL 요청
+	URL_NOT_FOUND(
+		NOT_FOUND,
+		"요청하신 URL을 찾을 수 없습니다",
+		"매핑된 핸들러 없는 URL 요청"),
+
+	// [405] 허용되지 않은 HTTP 메서드로 요청
+	METHOD_NOT_ALLOWED(
+		HttpStatus.METHOD_NOT_ALLOWED,
+		"지원하지 않는 HTTP 메서드입니다",
+		"허용되지 않은 HTTP 메서드 요청"),
+
+	// [415] 지원하지 않는 Content-Type 헤더
+	UNSUPPORTED_MEDIA_TYPE(
+		HttpStatus.UNSUPPORTED_MEDIA_TYPE,
+		"지원하지 않는 Content-Type 입니다",
+		"지원하지 않는 Content-Type 요청"),
+
+	// [500] DB 관련 에러
+	DATABASE_ERROR(
+		HttpStatus.INTERNAL_SERVER_ERROR,
+		"데이터베이스 오류가 발생했습니다",
+		"DB 관련 예외"),
+
+	// [500] 기타 서버 오류
+	INTERNAL_SERVER_ERROR(
+		HttpStatus.INTERNAL_SERVER_ERROR,
+		"서버 내부 오류가 발생했습니다",
+		"기타 서버 예외");
+
+	private final HttpStatus status;
+	private final String message;
+	private final String logMessage;
+}


### PR DESCRIPTION
## 📌 Summary
<!-- 이 PR이 무엇을 하는지 한 줄로 요약 -->
- 글로벌 및 챗봇 에러코드(enum) 정의와 공통 ErrorCode 인터페이스 추가

---

## 🎯 Background
<!-- 왜 이 변경이 필요한지 (이슈, 요구사항, 맥락) -->
- 챗봇 서비스 전반에서 일관된 에러 메시지와 HTTP 상태 코드 관리 필요
- 기존에는 개별적으로 분산된 에러 처리로 관리가 어려움
- 향후 AI 서비스와 글로벌 오류 처리 시 코드 재사용성과 유지보수성 향상

---

## 🔨 Changes
<!-- 주요 변경 사항을 구체적으로 -->
- `GlobalErrorCode` enum 추가: 공통 HTTP 오류 코드 및 메시지 정의  
- `ChatErrorCode` enum 추가: AI 서비스 관련 오류, 스트리밍, chatId 유효성 오류 정의  
- `ErrorCode` 인터페이스 추가: 모든 에러코드 enum 공통 구조화 (getStatus, getMessage, getLogMessage, name)  

---

## 📝 Notes
<!-- 리뷰어가 알면 좋은 추가 정보 -->
- 향후 AI 서비스 및 글로벌 API 오류 처리 시 본 enum 사용 권장  
