### PR TITLE
PR 알림용 Discord 메시지 추가

### DIFF
--- a/.github/workflows/pr-discord-notify.yml
+++ b/.github/workflows/pr-discord-notify.yml
@@ -1,0 +1,82 @@
+name: PR Discord Notification
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Send PR notification to Discord
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.PR_DISCORD_WEBHOOK_URL }}
+        run: |
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_URL="${{ github.event.pull_request.html_url }}"
+          PR_AUTHOR="${{ github.event.pull_request.user.login }}"
+          PR_AUTHOR_AVATAR="${{ github.event.pull_request.user.avatar_url }}"
+          PR_BASE="${{ github.event.pull_request.base.ref }}"
+          PR_HEAD="${{ github.event.pull_request.head.ref }}"
+          PR_ACTION="${{ github.event.action }}"
+          REPO_NAME="${{ github.repository }}"
+          PR_MERGED="${{ github.event.pull_request.merged }}"
+
+          # 상태별 색상 & 텍스트
+          if [ "$PR_ACTION" = "opened" ]; then
+            COLOR=3447003
+            STATUS_TEXT="PR이 생성되었습니다"
+          elif [ "$PR_ACTION" = "reopened" ]; then
+            COLOR=15844367
+            STATUS_TEXT="PR이 다시 열렸습니다"
+          elif [ "$PR_ACTION" = "synchronize" ]; then
+            COLOR=10181046
+            STATUS_TEXT="PR에 새로운 커밋이 추가되었습니다"
+          elif [ "$PR_ACTION" = "closed" ] && [ "$PR_MERGED" = "true" ]; then
+            COLOR=5763719
+            STATUS_TEXT="PR이 머지되었습니다"
+          else
+            COLOR=15158332
+            STATUS_TEXT="PR이 닫혔습니다"
+          fi
+
+          curl -H "Content-Type: application/json" \
+            -X POST \
+            -d "{
+              \"avatar_url\": \"https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png\",
+              \"embeds\": [
+                {
+                  \"title\": \"Pull Request 알림\",
+                  \"url\": \"${PR_URL}\",
+                  \"description\": \"**${PR_TITLE}**\",
+                  \"color\": ${COLOR},
+                  \"author\": {
+                    \"name\": \"${PR_AUTHOR}\",
+                    \"icon_url\": \"${PR_AUTHOR_AVATAR}\"
+                  },
+                  \"fields\": [
+                    {
+                      \"name\": \"저장소\",
+                      \"value\": \"`${REPO_NAME}`\",
+                      \"inline\": true
+                    },
+                    {
+                      \"name\": \"브랜치\",
+                      \"value\": \"`${PR_HEAD}` → `${PR_BASE}`\",
+                      \"inline\": true
+                    },
+                    {
+                      \"name\": \"상태\",
+                      \"value\": \"${STATUS_TEXT}\",
+                      \"inline\": false
+                    }
+                  ],
+                  \"footer\": {
+                    \"text\": \"GitHub Actions · PR Notification\"
+                  },
+                  \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"
+                }
+              ]
+            }" \
+            $DISCORD_WEBHOOK_URL

--- a/.github/workflows/pr-discord-notify.yml
+++ b/.github/workflows/pr-discord-notify.yml
@@ -41,42 +41,55 @@ jobs:
             STATUS_TEXT="PR이 닫혔습니다"
           fi
 
-          curl -H "Content-Type: application/json" \
-            -X POST \
-            -d "{
-              \"avatar_url\": \"https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png\",
-              \"embeds\": [
+          # 🔥 안전한 JSON 생성 (문자열 자동 escape)
+          PAYLOAD=$(jq -n \
+            --arg title "$PR_TITLE" \
+            --arg url "$PR_URL" \
+            --arg author "$PR_AUTHOR" \
+            --arg avatar "$PR_AUTHOR_AVATAR" \
+            --arg repo "$REPO_NAME" \
+            --arg head "$PR_HEAD" \
+            --arg base "$PR_BASE" \
+            --arg status "$STATUS_TEXT" \
+            --argjson color $COLOR \
+            '{
+              avatar_url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png",
+              embeds: [
                 {
-                  \"title\": \"Pull Request 알림\",
-                  \"url\": \"${PR_URL}\",
-                  \"description\": \"**${PR_TITLE}**\",
-                  \"color\": ${COLOR},
-                  \"author\": {
-                    \"name\": \"${PR_AUTHOR}\",
-                    \"icon_url\": \"${PR_AUTHOR_AVATAR}\"
+                  title: "Pull Request 알림",
+                  url: $url,
+                  description: ("**" + $title + "**"),
+                  color: $color,
+                  author: {
+                    name: $author,
+                    icon_url: $avatar
                   },
-                  \"fields\": [
+                  fields: [
                     {
-                      \"name\": \"저장소\",
-                      \"value\": \"`${REPO_NAME}`\",
-                      \"inline\": true
+                      name: "저장소",
+                      value: ("`" + $repo + "`"),
+                      inline: true
                     },
                     {
-                      \"name\": \"브랜치\",
-                      \"value\": \"`${PR_HEAD}` → `${PR_BASE}`\",
-                      \"inline\": true
+                      name: "브랜치",
+                      value: ("`" + $head + "` → `" + $base + "`"),
+                      inline: true
                     },
                     {
-                      \"name\": \"상태\",
-                      \"value\": \"${STATUS_TEXT}\",
-                      \"inline\": false
+                      name: "상태",
+                      value: $status,
+                      inline: false
                     }
                   ],
-                  \"footer\": {
-                    \"text\": \"GitHub Actions · PR Notification\"
+                  footer: {
+                    text: "GitHub Actions · PR Notification"
                   },
-                  \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"
+                  timestamp: (now | todate)
                 }
               ]
-            }" \
-            $DISCORD_WEBHOOK_URL
+            }')
+
+          curl -H "Content-Type: application/json" \
+               -X POST \
+               -d "$PAYLOAD" \
+               $DISCORD_WEBHOOK_URL


### PR DESCRIPTION
## 📌 Summary
- GitHub Pull Request 이벤트 발생 시 Discord 알림 워크플로 추가
- PR 상태 변화를 팀 채널에 자동 공유하도록 설정

---

## 🎯 Background
- PR 생성/수정/머지 여부를 실시간으로 확인하기 어려움
- 코드 리뷰 흐름 및 협업 가시성 개선 필요
- CI/CD 파이프라인 모니터링을 Discord 중심으로 통합하기 위함

---

## 🔨 Changes
- `PR Discord Notification` GitHub Actions 워크플로 신규 추가
- `pull_request` 이벤트 트리거 설정
  - opened
  - reopened
  - synchronize
  - closed
- PR 상태별 Discord Embed 색상 및 메시지 분기 처리
- 알림에 포함되는 정보 구성
  - PR 제목
  - 작성자
  - 브랜치 (head → base)
  - 저장소명
  - 상태 메시지
- Discord Webhook Secret (`PR_DISCORD_WEBHOOK_URL`) 사용 설정

---

## 📝 Notes
- Discord 채널에 봇 메시지 형태로 표시됨
- `username`, `avatar_url`은 조직 스타일에 맞게 변경 가능
- 향후 CI 성공/실패 알림과 연동 확장 가능
