### PR TITLE
LLM 비용 제어를 위한 사용량 추적 및 예외 처리 구조 추가

### DIFF
--- a/chatbot/backend/build.gradle
+++ b/chatbot/backend/build.gradle
@@ -59,6 +59,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-webflux-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/BackendApplication.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/BackendApplication.java
@@ -2,7 +2,9 @@ package com.hallachatbot.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
+@EnableAsync
 @SpringBootApplication
 public class BackendApplication {
 

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/global/errorcode/CostErrorCode.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/global/errorcode/CostErrorCode.java
@@ -1,0 +1,29 @@
+package com.hallachatbot.backend.global.errorcode;
+
+import static org.springframework.http.HttpStatus.FORBIDDEN;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * <b>비용(Cost) 도메인 관련 에러 코드 정의</b>
+ * <p>
+ * 비즈니스 로직 수행 중 발생하는 예외 상황을 체계적으로 관리하기 위한 Enum입니다.
+ * </p>
+ */
+@Getter
+@RequiredArgsConstructor
+public enum CostErrorCode implements ErrorCode {
+
+	// [403] 예산 초과
+	MONTHLY_LLM_BUDGET_EXCEEDED(
+		FORBIDDEN,
+		"이번 달 LLM 사용 한도를 초과하여 일시적으로 서비스 이용이 제한되었습니다.",
+		"LLM 예산 초과로 인한 이용 제한");
+
+	private final HttpStatus status;
+	private final String message;
+	private final String logMessage;
+}

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/global/exception/CostException.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/global/exception/CostException.java
@@ -1,0 +1,12 @@
+package com.hallachatbot.backend.global.exception;
+
+import com.hallachatbot.backend.global.errorcode.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CostException extends RuntimeException {
+	private final transient ErrorCode errorCode;
+}

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/usage/entity/MonthlyLlmUsage.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/usage/entity/MonthlyLlmUsage.java
@@ -1,0 +1,74 @@
+package com.hallachatbot.backend.usage.entity;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+import jakarta.validation.constraints.Pattern;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 월별 LLM 사용 비용 관리 엔티티
+ *
+ * <p>
+ * 키 : {@code monthly_llm_cost:{YYYY-MM}}<br>
+ * TTL: 60일
+ * </p>
+ *
+ * @author dryflowery
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@RedisHash(value = "monthly_llm_usage", timeToLive = 60 * 60 * 24 * 60)
+public class MonthlyLlmUsage implements Serializable {
+
+	/**
+	 * 월별 키 식별자 (Format: "YYYY-MM")
+	 */
+	@Id
+	@Pattern(regexp = "^\\d{4}-\\d{2}$", message = "기간 형식은 YYYY-MM 이어야 합니다 (e.g., 2026-01)")
+	private String period;
+
+	private BigDecimal totalUsage;
+
+	private LocalDateTime lastUpdated;
+
+	@Builder
+	public MonthlyLlmUsage(String period, BigDecimal totalUsage, LocalDateTime lastUpdated) {
+		this.period = period;
+		this.totalUsage = totalUsage;
+		this.lastUpdated = lastUpdated;
+	}
+
+	/**
+	 * 해당 월의 새로운 비용 객체를 생성
+	 * @param period "YYYY-MM" 형태의 문자열
+	 * @return 초기화된 {@link MonthlyLlmUsage} 객체
+	 */
+	public static MonthlyLlmUsage init(String period) {
+		return MonthlyLlmUsage.builder()
+			.period(period)
+			.totalUsage(BigDecimal.ZERO)
+			.lastUpdated(LocalDateTime.now())
+			.build();
+	}
+
+	/**
+	 * 비용 누적 및 상태 갱신
+	 * @param cost 추가할 비용 (USD)
+	 */
+	public void addCost(BigDecimal cost) {
+		if (this.totalUsage == null) {
+			this.totalUsage = BigDecimal.ZERO;
+		}
+
+		this.totalUsage = this.totalUsage.add(cost);
+		this.lastUpdated = LocalDateTime.now();
+	}
+}

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/usage/repository/MonthlyLlmUsageRepository.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/usage/repository/MonthlyLlmUsageRepository.java
@@ -1,0 +1,11 @@
+package com.hallachatbot.backend.usage.repository;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import com.hallachatbot.backend.usage.entity.MonthlyLlmUsage;
+
+@Repository
+public interface MonthlyLlmUsageRepository extends CrudRepository<MonthlyLlmUsage, String> {
+
+}

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/usage/service/UsageService.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/usage/service/UsageService.java
@@ -1,0 +1,50 @@
+package com.hallachatbot.backend.usage.service;
+
+import java.math.BigDecimal;
+
+import com.hallachatbot.backend.global.errorcode.CostErrorCode;
+import com.hallachatbot.backend.global.exception.CostException;
+import com.hallachatbot.backend.usage.entity.MonthlyLlmUsage;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+
+/**
+ * <b>월 단위 서비스 가용량 및 예산 관리 서비스</b>
+ *
+ * <p>주요 설계 원칙:</p>
+ * <ul>
+ * <li><b>자동 초기화:</b> 시스템 시각 기준, 매달 1일 00:00 시점에 별도 배치 없이 예산 집계 단위를 자동 전환</li>
+ * <li><b>회로 차단:</b> 설정된 임계치 도달 시 즉시 예외를 송출하여 인프라 비용 폭주 방지</li>
+ * </ul>
+ *
+ * @author dryflowery
+ */
+// todo: 기타 인프라 비용 체크
+// todo: 스케줄러로 하루 한 번 OpenAPI 서버에서 정확한 값 가져오기
+public interface UsageService {
+
+	/**
+	 * <b>현재 월의 LLM 사용량 임계치 초과 여부 검증</b>
+	 *
+	 * <p>
+	 * LLM API 요청 수행 직전 호출하여, 현시점 누적 사용액과 {@code app.monthly-llm-usage-limit} 설정값을 비교
+	 * </p>
+	 *
+	 * <ul>
+	 * <li><b>검증 대상:</b> {@link MonthlyLlmUsage#getTotalUsage()}</li>
+	 * <li><b>판단 기준:</b> 누적 사용액 >= 설정 한도</li>
+	 * <li><b>발생 에러:</b> {@link CostErrorCode#MONTHLY_LLM_BUDGET_EXCEEDED} (HTTP 403)</li>
+	 * </ul>
+	 *
+	 * @throws CostException 한도 초과 상태에서 호출될 경우 발생
+	 */
+	void checkLlmUsage();
+
+	/**
+	 * <b>LLM API 사용 비용 누적 기록</b>
+	 *
+	 * @param cost 발생한 사용 비용 (USD 단위)
+	 */
+	void addLlmUsage(@NotNull @PositiveOrZero BigDecimal cost);
+}

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/usage/service/UsageServiceImpl.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/usage/service/UsageServiceImpl.java
@@ -1,0 +1,61 @@
+package com.hallachatbot.backend.usage.service;
+
+import java.math.BigDecimal;
+import java.time.YearMonth;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
+
+import com.hallachatbot.backend.global.errorcode.CostErrorCode;
+import com.hallachatbot.backend.global.exception.CostException;
+import com.hallachatbot.backend.usage.entity.MonthlyLlmUsage;
+import com.hallachatbot.backend.usage.repository.MonthlyLlmUsageRepository;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@Validated
+@RequiredArgsConstructor
+public class UsageServiceImpl implements UsageService {
+
+	private final MonthlyLlmUsageRepository monthlyLlmUsageRepository;
+
+	@Value("${app.monthly-llm-usage-limit}")
+	private BigDecimal monthlyLlmUsageLimit;
+
+	@Override
+	public void checkLlmUsage() {
+		MonthlyLlmUsage usage = getMonthlyLlmUsage();
+
+		if (usage.getTotalUsage().compareTo(monthlyLlmUsageLimit) >= 0) {
+			throw new CostException(CostErrorCode.MONTHLY_LLM_BUDGET_EXCEEDED);
+		}
+	}
+
+	@Override
+	@Async
+	public void addLlmUsage(@NotNull @PositiveOrZero BigDecimal cost) {
+		try {
+			MonthlyLlmUsage usage = getMonthlyLlmUsage();
+			usage.addCost(cost);
+
+			monthlyLlmUsageRepository.save(usage);
+		} catch (Exception e) {
+			log.error("LLM 비용 저장 실패 (Cost: {})", cost, e);
+		}
+	}
+
+	private MonthlyLlmUsage getMonthlyLlmUsage() {
+		String currentPeriod = YearMonth.now().toString();
+
+		return monthlyLlmUsageRepository.findById(currentPeriod)
+			.orElseGet(() -> MonthlyLlmUsage.init(currentPeriod));
+	}
+}

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/usage/service/UsageServiceImpl.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/usage/service/UsageServiceImpl.java
@@ -6,7 +6,6 @@ import java.time.YearMonth;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 
 import com.hallachatbot.backend.global.errorcode.CostErrorCode;

--- a/chatbot/backend/src/main/resources/application.yml
+++ b/chatbot/backend/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
 app:
   # 기본값 설정 (config.py의 Default 값 반영)
   ai-service-url: "http://chatbot-ai-container:8000"
-  monthly-cost-limit: 1000.0
+  monthly-llm-usage-limit: 1000.0
 
   # CORS 설정
   cors:

--- a/chatbot/backend/src/test/java/com/hallachatbot/backend/usage/service/UsageServiceImplTest.java
+++ b/chatbot/backend/src/test/java/com/hallachatbot/backend/usage/service/UsageServiceImplTest.java
@@ -1,0 +1,114 @@
+package com.hallachatbot.backend.usage.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.math.BigDecimal;
+import java.time.YearMonth;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.hallachatbot.backend.global.errorcode.CostErrorCode;
+import com.hallachatbot.backend.global.exception.CostException;
+import com.hallachatbot.backend.usage.entity.MonthlyLlmUsage;
+import com.hallachatbot.backend.usage.repository.MonthlyLlmUsageRepository;
+
+@ExtendWith(MockitoExtension.class)
+class UsageServiceImplTest {
+
+	@InjectMocks
+	private UsageServiceImpl usageService;
+
+	@Mock
+	private MonthlyLlmUsageRepository usageRepository;
+
+	private static final BigDecimal LIMIT_AMOUNT = new BigDecimal("100.0"); // 100달러 한도
+
+	@BeforeEach
+	void setUp() {
+		// @Value 값을 Mock 객체에 주입
+		ReflectionTestUtils.setField(usageService, "monthlyLlmUsageLimit", LIMIT_AMOUNT);
+	}
+
+	@Test
+	@DisplayName("예산 한도 내라면 검증을 통과한다")
+	void checkLlmUsage_Success() {
+		// given
+		String period = YearMonth.now().toString();
+		MonthlyLlmUsage safeUsage = MonthlyLlmUsage.builder()
+			.period(period)
+			.totalUsage(new BigDecimal("50.0")) // 한도(100)보다 적음
+			.build();
+
+		given(usageRepository.findById(period)).willReturn(Optional.of(safeUsage));
+
+		// when & then (예외가 발생하지 않아야 함)
+		assertThatCode(() -> usageService.checkLlmUsage())
+			.doesNotThrowAnyException();
+	}
+
+	@Test
+	@DisplayName("예산 한도를 초과하면 예외를 발생시킨다")
+	void checkLlmUsage_Fail_Exceed() {
+		// given
+		String period = YearMonth.now().toString();
+		MonthlyLlmUsage exceededUsage = MonthlyLlmUsage.builder()
+			.period(period)
+			.totalUsage(new BigDecimal("100.1")) // 한도(100) 초과
+			.build();
+
+		given(usageRepository.findById(period)).willReturn(Optional.of(exceededUsage));
+
+		// when & then
+		assertThatThrownBy(() -> usageService.checkLlmUsage())
+			.isInstanceOf(CostException.class)
+			.hasFieldOrPropertyWithValue("errorCode", CostErrorCode.MONTHLY_LLM_BUDGET_EXCEEDED);
+	}
+
+	@Test
+	@DisplayName("이번 달 기록이 없으면(월초) 0원으로 간주하여 통과한다")
+	void checkLlmUsage_NewMonth() {
+		// given
+		String period = YearMonth.now().toString();
+		given(usageRepository.findById(period)).willReturn(Optional.empty()); // 데이터 없음
+
+		// when & then
+		assertThatCode(() -> usageService.checkLlmUsage())
+			.doesNotThrowAnyException();
+	}
+
+	@Test
+	@DisplayName("비용 추가 시 Repository save가 호출되어야 한다")
+	void addLlmUsage() {
+		// given
+		String period = YearMonth.now().toString();
+		BigDecimal newCost = new BigDecimal("0.5");
+
+		// Mock: 기존에 10달러 썼던 기록이 있다고 가정
+		MonthlyLlmUsage existingUsage = MonthlyLlmUsage.builder()
+			.period(period)
+			.totalUsage(new BigDecimal("10.0"))
+			.build();
+
+		given(usageRepository.findById(period)).willReturn(Optional.of(existingUsage));
+
+		// when
+		usageService.addLlmUsage(newCost);
+
+		// then
+		// 1. save 메서드가 호출되었는지 검증
+		verify(usageRepository, times(1)).save(any(MonthlyLlmUsage.class));
+
+		// 2. 값이 제대로 더해졌는지 검증 (10.0 + 0.5 = 10.5)
+		assertThat(existingUsage.getTotalUsage()).isEqualTo(new BigDecimal("10.5"));
+	}
+}


### PR DESCRIPTION
## 📌 Summary
<!-- 이 PR이 무엇을 하는지 한 줄로 요약 -->
- 월별 LLM 사용량 추적, 예산 초과 차단 로직, 비용 도메인 예외 체계 및 인프라 설정을 추가하여 LLM 비용 제어 기반 구조를 구축

---

## 🎯 Background
<!-- 왜 이 변경이 필요한지 (이슈, 요구사항, 맥락) -->
- LLM API 사용량 증가 시 인프라 비용이 예측 없이 급증할 수 있는 구조였음  
- 월 단위 사용량 집계 및 한도 초과 시 차단하는 비용 보호 장치 필요  

---

## 🔨 Changes
<!-- 주요 변경 사항을 구체적으로 -->
- **Cost 도메인 예외 체계 추가**
  - `CostErrorCode` Enum 정의
  - `CostException` 커스텀 예외 클래스 추가
- **LLM 월별 사용량 관리 기능 구현**
  - Redis 엔티티 `MonthlyLlmUsage` 추가 (TTL 60일)
  - `MonthlyLlmUsageRepository` 생성
  - `UsageService` / `UsageServiceImpl` 구현
    - 사용량 한도 초과 시 예외 발생
    - 사용 비용 누적 로직 비동기 처리(@Async)
- **애플리케이션 설정 및 인프라 구성 변경**
  - 설정 키 `monthly-cost-limit` → `monthly-llm-usage-limit` 로 변경
  - `@EnableAsync` 추가로 비동기 기능 활성화
  - `spring-boot-starter-data-redis` 의존성 추가

---

## 🧪 Test & Verification
<!-- 어떻게 검증했는지 -->
- [x] 로컬 테스트 완료

---

## 📝 Notes
<!-- 리뷰어가 알면 좋은 추가 정보 -->
- 현재 사용량은 애플리케이션 기준 누적 값이며, 추후 OpenAPI 실제 청구 데이터와 동기화 예정(하루 한 번)
- 비용 제어 로직은 이후 다른 외부 API 비용 관리로 확장 가능
