### PR TITLE
챗봇 만족도 설문 제출 기능 구현

### DIFF
--- a/chatbot/backend/build.gradle
+++ b/chatbot/backend/build.gradle
@@ -60,17 +60,25 @@ jacocoTestReport {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
-    implementation 'org.springframework.boot:spring-boot-starter-validation'
-    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    // Web and API Documentation
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+
+    // Database and Cache
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // Validation and Tools
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     compileOnly 'org.projectlombok:lombok'
-    developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.projectlombok:lombok'
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+
+    // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.projectreactor:reactor-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/global/db/mongodb/MongoConfig.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/global/db/mongodb/MongoConfig.java
@@ -1,0 +1,9 @@
+package com.hallachatbot.backend.global.db.mongodb;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
+
+@Configuration
+@EnableMongoAuditing
+public class MongoConfig {
+}

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/global/exception/GlobalExceptionHandler.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/global/exception/GlobalExceptionHandler.java
@@ -19,14 +19,14 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 
 import com.hallachatbot.backend.global.errorcode.ErrorCode;
 import com.hallachatbot.backend.global.errorcode.GlobalErrorCode;
-import com.hallachatbot.backend.global.response.ApiResponse;
+import com.hallachatbot.backend.global.response.Response;
 
 import lombok.extern.slf4j.Slf4j;
 
 /**
  * 전역 예외 처리 핸들러 (Global Exception Handler).
  * <p>
- * 애플리케이션 전역에서 발생하는 예외를 포착하여 표준화된 {@link ApiResponse} 포맷으로 응답합니다.
+ * 애플리케이션 전역에서 발생하는 예외를 포착하여 표준화된 {@link Response} 포맷으로 응답합니다.
  * {@link ResponseEntityExceptionHandler}를 상속받아 Spring MVC 표준 예외를 커스터마이징 하여 적용합니다.
  * </p>
  *
@@ -173,6 +173,6 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
 		return ResponseEntity
 			.status(errorCode.getStatus())
-			.body(ApiResponse.fail(errorCode));
+			.body(Response.fail(errorCode));
 	}
 }

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/global/response/Response.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/global/response/Response.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.hallachatbot.backend.global.errorcode.ErrorCode;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record ApiResponse<T>(
+public record Response<T>(
 	boolean isSuccess,
 	String errorCode,
 	String errorMessage,
@@ -12,17 +12,17 @@ public record ApiResponse<T>(
 ) {
 
 	// 1. 성공 응답 (데이터 있음)
-	public static <T> ApiResponse<T> success(T data) {
-		return new ApiResponse<>(true, null, null, data);
+	public static <T> Response<T> success(T data) {
+		return new Response<>(true, null, null, data);
 	}
 
 	// 2. 성공 응답 (데이터 없음)
-	public static <T> ApiResponse<T> success() {
-		return new ApiResponse<>(true, null, null, null);
+	public static <T> Response<T> success() {
+		return new Response<>(true, null, null, null);
 	}
 
 	// 3. 실패 응답
-	public static <T> ApiResponse<T> fail(ErrorCode errorCode) {
-		return new ApiResponse<>(false, errorCode.name(), errorCode.getMessage(), null);
+	public static <T> Response<T> fail(ErrorCode errorCode) {
+		return new Response<>(false, errorCode.name(), errorCode.getMessage(), null);
 	}
 }

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/survey/controller/SurveyController.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/survey/controller/SurveyController.java
@@ -1,0 +1,54 @@
+package com.hallachatbot.backend.survey.controller;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.hallachatbot.backend.global.response.Response;
+import com.hallachatbot.backend.survey.dto.request.ChatSurveyRequest;
+import com.hallachatbot.backend.survey.service.SurveyService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * <b>설문조사 API 컨트롤러</b>
+ *
+ * <p>
+ *     클라이언트의 설문 제출 요청을 수신하고 서비스 계층으로 위임
+ * </p>
+ */
+@Tag(name = "Survey", description = "설문조사 API")
+@RestController
+@RequestMapping("/api/survey")
+@RequiredArgsConstructor
+public class SurveyController {
+
+	private final SurveyService surveyServiceImpl;
+
+	/**
+	 * <b>챗봇 만족도 설문 제출</b>
+	 * <p>
+	 *     챗봇 이용 후 작성한 만족도, 속도, 품질 등에 대한 설문을 접수
+	 * </p>
+	 *
+	 * @param request 설문 내용이 담긴 요청 바디 {@link ChatSurveyRequest}
+	 */
+	@Operation(summary = "챗봇 만족도 설문 제출", description = "사용자의 학적 정보와 챗봇 이용 경험(평점, 속도, 품질)을 저장")
+	@ApiResponses(value = {
+		// todo: Swagger Response 주석 모으기
+		@ApiResponse(responseCode = "200", description = "설문 제출 성공"),
+		@ApiResponse(responseCode = "400", description = "INVALID_INPUT_VALUE | etc.."),
+		@ApiResponse(responseCode = "500", description = "INTERNAL_SERVER_ERROR | DATABASE_ERROR")
+	})
+	@PostMapping("/chat")
+	public Response<Void> submitChatSurvey(@RequestBody @Valid ChatSurveyRequest request) {
+		surveyServiceImpl.submitChatSurvey(request);
+		return Response.success();
+	}
+}

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/survey/dto/request/ChatSurveyRequest.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/survey/dto/request/ChatSurveyRequest.java
@@ -1,0 +1,55 @@
+package com.hallachatbot.backend.survey.dto.request;
+
+import com.hallachatbot.backend.survey.entity.ChatSurvey;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+/**
+ * <b>챗봇 사용 만족도 설문 요청 DTO</b>
+ */
+@Schema(description = "챗봇 만족도 설문 제출 요청 데이터")
+public record ChatSurveyRequest(
+
+	@Schema(description = "사용자 카테고리 (학적/신분)", allowableValues = {"1학년", "2학년", "3학년", "4학년", "대학원생", "교직원", "외부인"})
+	@NotNull(message = "사용자 카테고리는 필수입니다.")
+	@Pattern(
+		regexp = "^(1학년|2학년|3학년|4학년|대학원생|교직원|외부인)$",
+		message = "올바르지 않은 사용자 카테고리입니다."
+	)
+	String userCategory,
+
+	@Schema(description = "만족도 평점", minimum = "1", maximum = "5")
+	@NotNull(message = "평점 입력은 필수입니다.")
+	@Min(value = 1, message = "평점은 최소 1점이어야 합니다.")
+	@Max(value = 5, message = "평점은 최대 5점이어야 합니다.")
+	int rating,
+
+	@Schema(description = "챗봇 응답 속도 체감", allowableValues = {"high", "mid", "low"})
+	@NotNull(message = "응답 속도 평가는 필수입니다.")
+	@Pattern(regexp = "^(high|mid|low)$", message = "응답 속도는 'high', 'mid', 'low' 중 하나여야 합니다.")
+	String responseSpeed,
+
+	@Schema(description = "챗봇 답변 품질 체감", allowableValues = {"high", "mid", "low"})
+	@NotNull(message = "응답 품질 평가는 필수입니다.")
+	@Pattern(regexp = "^(high|mid|low)$", message = "응답 품질은 'high', 'mid', 'low' 중 하나여야 합니다.")
+	String responseQuality,
+
+	@Schema(description = "기타 건의사항 및 코멘트", maxLength = 100)
+	@Size(max = 100, message = "코멘트는 100자를 초과할 수 없습니다.")
+	String comment
+) {
+	public ChatSurvey toEntity() {
+		return ChatSurvey.builder()
+			.userCategory(this.userCategory)
+			.rating(this.rating)
+			.responseSpeed(this.responseSpeed)
+			.responseQuality(this.responseQuality)
+			.comment(this.comment)
+			.build();
+	}
+}

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/survey/entity/ChatSurvey.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/survey/entity/ChatSurvey.java
@@ -1,0 +1,57 @@
+package com.hallachatbot.backend.survey.entity;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * <b>챗봇 만족도 설문 엔티티</b>
+ *
+ * <ul>
+ * <li><b>DB:</b> MongoDB</li>
+ * <li><b>컬렉션:</b> {@code chat_survey}</li>
+ * <li><b>특징:</b> 생성 시간 자동 기록</li>
+ * </ul>
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Document(collection = "survey${app.mongodb.suffix:}")
+public class ChatSurvey {
+
+	@Id
+	private String id;
+
+	@Field("user_category")
+	private String userCategory;
+
+	private int rating;
+
+	@Field("response_speed")
+	private String responseSpeed;
+
+	@Field("response_quality")
+	private String responseQuality;
+
+	private String comment;
+
+	@CreatedDate
+	@Field("date")
+	private LocalDateTime date;
+
+	@Builder
+	public ChatSurvey(String userCategory, int rating, String responseSpeed, String responseQuality, String comment) {
+		this.userCategory = userCategory;
+		this.rating = rating;
+		this.responseSpeed = responseSpeed;
+		this.responseQuality = responseQuality;
+		this.comment = comment;
+	}
+}

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/survey/repository/ChatSurveyRepository.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/survey/repository/ChatSurveyRepository.java
@@ -1,0 +1,18 @@
+package com.hallachatbot.backend.survey.repository;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import com.hallachatbot.backend.survey.entity.ChatSurvey;
+
+/**
+ * <b>챗봇 설문 데이터 접근 리포지토리</b>
+ *
+ * <ul>
+ * <li><b>대상 엔티티:</b> {@link ChatSurvey}</li>
+ * <li><b>Key 타입:</b> MongoDB ObjectId</li>
+ * </ul>
+ */
+@Repository
+public interface ChatSurveyRepository extends MongoRepository<ChatSurvey, String> {
+}

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/survey/service/SurveyService.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/survey/service/SurveyService.java
@@ -1,0 +1,25 @@
+package com.hallachatbot.backend.survey.service;
+
+import com.hallachatbot.backend.survey.dto.request.ChatSurveyRequest;
+
+/**
+ * <b>설문조사 비즈니스 로직 처리 서비스</b>
+ *
+ * <ul>
+ * <li><b>역할:</b> 다양한 유형의 설문(챗봇 만족도, 사용자 조사 등) 데이터 처리 및 저장</li>
+ * <li><b>현재 설문:</b> 챗봇 만족도 설문({@code ChatSurvey})</li>
+ * </ul>
+ */
+public interface SurveyService {
+
+	/**
+	 * <b>챗봇 만족도 설문 제출 처리</b>
+	 * * <ul>
+	 * <li><b>동작:</b> 요청 DTO를 엔티티로 변환 후 MongoDB에 영구 저장</li>
+	 * <li><b>트랜잭션:</b> 쓰기 작업에 대한 단일 트랜잭션 보장</li>
+	 * </ul>
+	 *
+	 * @param request 유효성 검증이 완료된 설문 요청 데이터
+	 */
+	void submitChatSurvey(ChatSurveyRequest request);
+}

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/survey/service/SurveyServiceImpl.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/survey/service/SurveyServiceImpl.java
@@ -1,0 +1,28 @@
+package com.hallachatbot.backend.survey.service;
+
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.hallachatbot.backend.survey.dto.request.ChatSurveyRequest;
+import com.hallachatbot.backend.survey.repository.ChatSurveyRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SurveyServiceImpl implements SurveyService {
+
+	private final ChatSurveyRepository chatSurveyRepository;
+
+	@Override
+	@Transactional
+	public void submitChatSurvey(ChatSurveyRequest request) {
+		chatSurveyRepository.save(request.toEntity());
+		log.info("설문조사 저장 완료: {}", LocalDateTime.now()
+		);
+	}
+}

--- a/chatbot/backend/src/test/java/com/hallachatbot/backend/survey/controller/SurveyControllerTest.java
+++ b/chatbot/backend/src/test/java/com/hallachatbot/backend/survey/controller/SurveyControllerTest.java
@@ -1,0 +1,97 @@
+package com.hallachatbot.backend.survey.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hallachatbot.backend.survey.dto.request.ChatSurveyRequest;
+import com.hallachatbot.backend.survey.service.SurveyService;
+
+@WebMvcTest(SurveyController.class)
+class SurveyControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockitoBean
+	private SurveyService surveyService;
+
+	@Test
+	@DisplayName("설문 제출 성공 - 유효한 데이터가 들어오면 200 OK를 반환한다")
+	void submitChatSurvey_Success() throws Exception {
+		// given
+		ChatSurveyRequest request = new ChatSurveyRequest(
+			"1학년",
+			5,
+			"high",
+			"high",
+			"만족합니다."
+		);
+
+		willDoNothing().given(surveyService).submitChatSurvey(any(ChatSurveyRequest.class));
+
+		// when & then
+		mockMvc.perform(post("/api/survey/chat")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.isSuccess").value(true));
+		// Response 객체 구조에 따라 jsonPath는 조정 필요
+	}
+
+	@Test
+	@DisplayName("설문 제출 실패 - 필수값이 누락되면 400 Bad Request를 반환한다")
+	void submitChatSurvey_Fail_NullField() throws Exception {
+		// given
+		ChatSurveyRequest invalidRequest = new ChatSurveyRequest(
+			null,   // userCategory (Null 불가)
+			5,
+			"high",
+			"high",
+			"코멘트"
+		);
+
+		// when & then
+		mockMvc.perform(post("/api/survey/chat")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(invalidRequest)))
+			.andDo(print())
+			.andExpect(status().isBadRequest());
+	}
+
+	@Test
+	@DisplayName("설문 제출 실패 - 평점 범위를 벗어나면 400 Bad Request를 반환한다")
+	void submitChatSurvey_Fail_InvalidRating() throws Exception {
+		// given
+		ChatSurveyRequest invalidRequest = new ChatSurveyRequest(
+			"1학년",
+			10,     // rating (Max 5 위반)
+			"high",
+			"high",
+			"코멘트"
+		);
+
+		// when & then
+		mockMvc.perform(post("/api/survey/chat")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(invalidRequest)))
+			.andDo(print())
+			.andExpect(status().isBadRequest());
+	}
+}

--- a/chatbot/backend/src/test/java/com/hallachatbot/backend/survey/service/SurveyServiceImplTest.java
+++ b/chatbot/backend/src/test/java/com/hallachatbot/backend/survey/service/SurveyServiceImplTest.java
@@ -1,0 +1,58 @@
+package com.hallachatbot.backend.survey.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.hallachatbot.backend.survey.dto.request.ChatSurveyRequest;
+import com.hallachatbot.backend.survey.entity.ChatSurvey;
+import com.hallachatbot.backend.survey.repository.ChatSurveyRepository;
+
+@ExtendWith(MockitoExtension.class)
+class SurveyServiceImplTest {
+
+	@InjectMocks
+	private SurveyServiceImpl surveyService;
+
+	@Mock
+	private ChatSurveyRepository chatSurveyRepository;
+
+	@Test
+	@DisplayName("설문 제출 시 리포지토리의 save 메서드가 올바르게 호출되어야 한다")
+	void submitChatSurvey_Success() {
+		// given
+		ChatSurveyRequest request = new ChatSurveyRequest(
+			"1학년",
+			5,
+			"high",
+			"high",
+			"좋아요"
+		);
+
+		// when
+		surveyService.submitChatSurvey(request);
+
+		// then
+		// 1. save 호출 횟수 검증
+		verify(chatSurveyRepository, times(1)).save(any(ChatSurvey.class));
+
+		// 2. 전달된 데이터 정합성 검증
+		ArgumentCaptor<ChatSurvey> captor = ArgumentCaptor.forClass(ChatSurvey.class);
+		verify(chatSurveyRepository).save(captor.capture());
+
+		ChatSurvey savedEntity = captor.getValue();
+
+		assertThat(savedEntity.getUserCategory()).isEqualTo(request.userCategory());
+		assertThat(savedEntity.getRating()).isEqualTo(request.rating());
+		assertThat(savedEntity.getComment()).isEqualTo(request.comment());
+	}
+}


### PR DESCRIPTION
## 📌 Summary  
<!-- 이 PR이 무엇을 하는지 한 줄로 요약 -->
- 챗봇 만족도 설문 제출 기능 신규 구현

---

## 🎯 Background  
<!-- 왜 이 변경이 필요한지 (이슈, 요구사항, 맥락) -->
- 챗봇 서비스 품질 개선을 위한 사용자 만족도 데이터 수집 기능이 필요함  
- 향후 통계 분석 및 서비스 개선 지표로 활용하기 위한 기초 데이터 적재 구조 마련

---

## 🔨 Changes  
<!-- 주요 변경 사항을 구체적으로 -->
- 기존의 공통 응답 포맷으로 사용하던 ApiResponse.java 이름 변경
  - swagger의 ApiResponse와의 중복으로 인해 Response.java로 변경
- MongoDB Auditing 활성화를 위한 `MongoConfig` 설정 추가  
- 챗봇 만족도 설문 MongoDB 엔티티 `ChatSurvey` 생성  
  - `@CreatedDate` 기반 생성일 자동 기록  
  - 컬렉션: `survey${app.mongodb.suffix:}`  
- `ChatSurveyRepository` 추가 (MongoRepository)  
- 설문 요청 DTO `ChatSurveyRequest` 정의 및 유효성 검증 규칙 적용  
- 설문 제출 API `POST /api/survey/chat` 구현  
- `SurveyService` 계층에 설문 저장 비즈니스 로직 추가  

---

## 🧪 Test & Verification  
<!-- 어떻게 검증했는지 -->
- [] todo: 로컬 테스트

---

## 📝 Notes  
<!-- 리뷰어가 알면 좋은 추가 정보 -->
- chat 기능에서 사용하는 MongoDB 설정 파일과 conflict 가능성이 있어, application.yml에는 관련 환경변수를 추가하지 않음
- chat 브랜치 merge 이후 통합 환경에서 로컬 테스트를 진행할 예정
