### PR TITLE
Cost 도메인 네이밍을 Usage 기준으로 통일

### DIFF
--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/global/errorcode/UsageErrorCode.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/global/errorcode/UsageErrorCode.java
@@ -15,7 +15,7 @@ import lombok.RequiredArgsConstructor;
  */
 @Getter
 @RequiredArgsConstructor
-public enum CostErrorCode implements ErrorCode {
+public enum UsageErrorCode implements ErrorCode {
 
 	// [403] 예산 초과
 	MONTHLY_LLM_BUDGET_EXCEEDED(

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/global/exception/UsageException.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/global/exception/UsageException.java
@@ -7,6 +7,6 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public class CostException extends RuntimeException {
+public class UsageException extends RuntimeException {
 	private final transient ErrorCode errorCode;
 }

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/usage/service/UsageService.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/usage/service/UsageService.java
@@ -2,8 +2,8 @@ package com.hallachatbot.backend.usage.service;
 
 import java.math.BigDecimal;
 
-import com.hallachatbot.backend.global.errorcode.CostErrorCode;
-import com.hallachatbot.backend.global.exception.CostException;
+import com.hallachatbot.backend.global.errorcode.UsageErrorCode;
+import com.hallachatbot.backend.global.exception.UsageException;
 import com.hallachatbot.backend.usage.entity.MonthlyLlmUsage;
 
 import jakarta.validation.constraints.NotNull;
@@ -34,10 +34,10 @@ public interface UsageService {
 	 * <ul>
 	 * <li><b>검증 대상:</b> {@link MonthlyLlmUsage#getTotalUsage()}</li>
 	 * <li><b>판단 기준:</b> 누적 사용액 >= 설정 한도</li>
-	 * <li><b>발생 에러:</b> {@link CostErrorCode#MONTHLY_LLM_BUDGET_EXCEEDED} (HTTP 403)</li>
+	 * <li><b>발생 에러:</b> {@link UsageErrorCode#MONTHLY_LLM_BUDGET_EXCEEDED} (HTTP 403)</li>
 	 * </ul>
 	 *
-	 * @throws CostException 한도 초과 상태에서 호출될 경우 발생
+	 * @throws UsageException 한도 초과 상태에서 호출될 경우 발생
 	 */
 	void checkLlmUsage();
 

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/usage/service/UsageServiceImpl.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/usage/service/UsageServiceImpl.java
@@ -8,8 +8,8 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.validation.annotation.Validated;
 
-import com.hallachatbot.backend.global.errorcode.CostErrorCode;
-import com.hallachatbot.backend.global.exception.CostException;
+import com.hallachatbot.backend.global.errorcode.UsageErrorCode;
+import com.hallachatbot.backend.global.exception.UsageException;
 import com.hallachatbot.backend.usage.entity.MonthlyLlmUsage;
 import com.hallachatbot.backend.usage.repository.MonthlyLlmUsageRepository;
 
@@ -34,7 +34,7 @@ public class UsageServiceImpl implements UsageService {
 		MonthlyLlmUsage usage = getMonthlyLlmUsage();
 
 		if (usage.getTotalUsage().compareTo(monthlyLlmUsageLimit) >= 0) {
-			throw new CostException(CostErrorCode.MONTHLY_LLM_BUDGET_EXCEEDED);
+			throw new UsageException(UsageErrorCode.MONTHLY_LLM_BUDGET_EXCEEDED);
 		}
 	}
 

--- a/chatbot/backend/src/test/java/com/hallachatbot/backend/usage/service/UsageServiceImplTest.java
+++ b/chatbot/backend/src/test/java/com/hallachatbot/backend/usage/service/UsageServiceImplTest.java
@@ -17,8 +17,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import com.hallachatbot.backend.global.errorcode.CostErrorCode;
-import com.hallachatbot.backend.global.exception.CostException;
+import com.hallachatbot.backend.global.errorcode.UsageErrorCode;
+import com.hallachatbot.backend.global.exception.UsageException;
 import com.hallachatbot.backend.usage.entity.MonthlyLlmUsage;
 import com.hallachatbot.backend.usage.repository.MonthlyLlmUsageRepository;
 
@@ -70,8 +70,8 @@ class UsageServiceImplTest {
 
 		// when & then
 		assertThatThrownBy(() -> usageService.checkLlmUsage())
-			.isInstanceOf(CostException.class)
-			.hasFieldOrPropertyWithValue("errorCode", CostErrorCode.MONTHLY_LLM_BUDGET_EXCEEDED);
+			.isInstanceOf(UsageException.class)
+			.hasFieldOrPropertyWithValue("errorCode", UsageErrorCode.MONTHLY_LLM_BUDGET_EXCEEDED);
 	}
 
 	@Test


### PR DESCRIPTION
## 📌 Summary
- Cost 관련 예외 및 에러코드 네이밍을 Usage 도메인 기준으로 통일

---

## 🎯 Background
- Usage 기준으로 도메인 개념이 정리되면서 , 기존 Cost 네이밍이 도메인 의미와 맞지 않는 문제가 있었음
- 예외 및 에러코드 계층에서 용어가 혼재되어 있어 유지보수 시 혼란 가능성 존재

---

## 🔨 Changes
- CostErrorCode → UsageErrorCode 네이밍 기준 정리
- CostException → UsageException 구조로 명칭 통일
- 도메인 의미(Usage)와 예외 계층 용어 일관성 확보
- 기능 변경 없음 (동작 로직 영향 없음)

---

## 🧪 Test & Verification
- [x] 로컬 테스트 완료
- [x] 기존 기능 영향도 확인 (네이밍 변경만 존재)
