### PR TITLE
chat 도메인의 전체적인 리팩토링 및 기능 추가

### DIFF
--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/component/ChatMapper.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/component/ChatMapper.java
@@ -9,6 +9,21 @@ import org.springframework.stereotype.Component;
 import com.hallachatbot.backend.domain.chat.dto.response.ChatHistoryResponse;
 import com.hallachatbot.backend.domain.chat.entity.ChatMessage;
 
+/**
+ * <b>채팅 데이터 변환 컴포넌트 (Mapper)</b>
+ *
+ * <p>
+ * 데이터베이스 엔티티({@link ChatMessage})를 클라이언트 및 AI 서비스가 사용하는
+ * DTO 포맷({@link ChatHistoryResponse})으로 변환하는 역할을 수행
+ * </p>
+ *
+ * <ul>
+ * <li><b>주요 기능:</b> DB에서 조회된 메시지 리스트를 AI 문맥(Context)에 맞는 순서(과거 -> 현재)로 재정렬하고 포맷팅</li>
+ * </ul>
+ *
+ * @author pwk0131
+ */
+
 @Component
 public class ChatMapper {
 

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/component/ChatMapper.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/component/ChatMapper.java
@@ -1,0 +1,27 @@
+package com.hallachatbot.backend.domain.chat.component;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.springframework.stereotype.Component;
+
+import com.hallachatbot.backend.domain.chat.dto.response.ChatHistoryResponse;
+import com.hallachatbot.backend.domain.chat.entity.ChatMessage;
+
+@Component
+public class ChatMapper {
+
+	public List<ChatHistoryResponse> toHistoryResponse(List<ChatMessage> rawHistory) {
+		// 원본 리스트 보호를 위해 복사본 생성 후 역순 정렬 (과거 -> 현재)
+		List<ChatMessage> sortedHistory = new java.util.ArrayList<>(rawHistory);
+		Collections.reverse(sortedHistory);
+
+		return sortedHistory.stream()
+			.flatMap(msg -> Stream.of(
+				ChatHistoryResponse.user(msg.getQuestion()),
+				ChatHistoryResponse.assistant(msg.getAnswer())
+			))
+			.toList();
+	}
+}

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/component/ChatReader.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/component/ChatReader.java
@@ -1,0 +1,29 @@
+package com.hallachatbot.backend.domain.chat.component;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.hallachatbot.backend.domain.chat.dto.response.ChatHistoryResponse;
+import com.hallachatbot.backend.domain.chat.entity.ChatMessage;
+import com.hallachatbot.backend.domain.chat.repository.ChatMessageRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChatReader {
+
+	private final ChatMessageRepository chatMessageRepository;
+	private final ChatMapper chatMapper;
+
+	public List<ChatHistoryResponse> getChatHistory(String chatId) {
+		// 1. DB 조회 (최신순 6개)
+		List<ChatMessage> rawHistory = chatMessageRepository.findTop6ByChatIdOrderByCreatedDateDesc(chatId);
+
+		// 2. 변환 위임
+		return chatMapper.toHistoryResponse(rawHistory);
+	}
+}

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/component/ChatReader.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/component/ChatReader.java
@@ -11,6 +11,18 @@ import com.hallachatbot.backend.domain.chat.repository.ChatMessageRepository;
 
 import lombok.RequiredArgsConstructor;
 
+/**
+ * <b>대화 내역 조회 컴포넌트 (Reader)</b>
+ *
+ * <p>
+ * 데이터베이스로부터 과거 대화 내역을 읽어오는 책임을 가지는 클래스
+ * {@link Transactional} (readOnly=true) 환경에서 동작하며, 조회된 데이터를
+ * {@link ChatMapper}를 통해 필요한 포맷으로 변환하여 반환
+ * </p>
+ *
+ * @author pwk0131
+ */
+
 @Component
 @RequiredArgsConstructor
 @Transactional(readOnly = true)

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/component/ChatReader.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/component/ChatReader.java
@@ -25,7 +25,6 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class ChatReader {
 
 	private final ChatMessageRepository chatMessageRepository;

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/component/ChatStreamHandler.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/component/ChatStreamHandler.java
@@ -1,0 +1,46 @@
+package com.hallachatbot.backend.domain.chat.component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.stereotype.Component;
+
+import com.hallachatbot.backend.domain.chat.service.ChatStreamContext;
+import com.hallachatbot.backend.global.client.dto.AiServiceResponse;
+import com.hallachatbot.backend.global.sse.SseEventFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ChatStreamHandler {
+
+	private final SseEventFactory sseEventFactory;
+
+	public ServerSentEvent<String> processAiResponse(AiServiceResponse response, ChatStreamContext context) {
+		String type = response.getType();
+
+		if ("delta".equals(type)) {
+			String content = response.getContent();
+			if (content != null) {
+				context.appendAnswer(content);
+			}
+			return sseEventFactory.createDelta(content);
+
+		} else if ("metadata".equals(type)) {
+			Map<String, Object> data = response.getData();
+			context.updateMetadata(data);
+
+			Map<String, Object> eventData = data != null ? new HashMap<>(data) : new HashMap<>();
+			eventData.put("chatId", context.getChatId());
+
+			return sseEventFactory.createMetadata(eventData);
+
+		} else if ("error".equals(type)) {
+			return sseEventFactory.createError(response.getData(), response.getMessage());
+		}
+
+		return sseEventFactory.createKeepAlive();
+	}
+}

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/component/ChatStreamHandler.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/component/ChatStreamHandler.java
@@ -34,17 +34,17 @@ public class ChatStreamHandler {
 	private final SseEventFactory sseEventFactory;
 
 	public ServerSentEvent<String> processAiResponse(AiServiceResponse response, ChatStreamContext context) {
-		String type = response.getType();
+		String type = response.type();
 
 		if ("delta".equals(type)) {
-			String content = response.getContent();
+			String content = response.content();
 			if (content != null) {
 				context.appendAnswer(content);
 			}
 			return sseEventFactory.createDelta(content);
 
 		} else if ("metadata".equals(type)) {
-			Map<String, Object> data = response.getData();
+			Map<String, Object> data = response.data();
 			context.updateMetadata(data);
 
 			Map<String, Object> eventData = data != null ? new HashMap<>(data) : new HashMap<>();
@@ -53,7 +53,7 @@ public class ChatStreamHandler {
 			return sseEventFactory.createMetadata(eventData);
 
 		} else if ("error".equals(type)) {
-			return sseEventFactory.createError(response.getData(), response.getMessage());
+			return sseEventFactory.createError(response.data(), response.message());
 		}
 
 		return sseEventFactory.createKeepAlive();

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/component/ChatStreamHandler.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/component/ChatStreamHandler.java
@@ -12,6 +12,21 @@ import com.hallachatbot.backend.global.sse.SseEventFactory;
 
 import lombok.RequiredArgsConstructor;
 
+/**
+ * <b>채팅 스트림 응답 처리 핸들러</b>
+ *
+ * <p>
+ * AI 서비스로부터 들어오는 스트리밍 응답({@link AiServiceResponse})을 실시간으로 분석하여
+ * 클라이언트에게 전송할 SSE 이벤트({@link ServerSentEvent})로 변환
+ * </p>
+ *
+ * <ul>
+ * <li><b>Context 업데이트:</b> 스트리밍되는 답변 조각(Delta)과 메타데이터를 {@link ChatStreamContext}에 누적</li>
+ * <li><b>이벤트 생성:</b> Delta, Metadata, Error 등 타입에 맞는 SSE 이벤트를 생성</li>
+ * </ul>
+ * @author pwk0131
+ */
+
 @Component
 @RequiredArgsConstructor
 public class ChatStreamHandler {

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/component/ChatWriter.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/component/ChatWriter.java
@@ -1,0 +1,64 @@
+package com.hallachatbot.backend.domain.chat.component;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.hallachatbot.backend.domain.chat.entity.ChatMessage;
+import com.hallachatbot.backend.domain.chat.entity.ChatMetadata;
+import com.hallachatbot.backend.domain.chat.entity.ChatTokenUsage;
+import com.hallachatbot.backend.domain.chat.repository.ChatMessageRepository;
+import com.hallachatbot.backend.domain.chat.repository.ChatMetadataRepository;
+import com.hallachatbot.backend.domain.chat.repository.ChatTokenUsageRepository;
+import com.hallachatbot.backend.domain.chat.service.ChatStreamContext;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChatWriter {
+
+	private final ChatMessageRepository chatMessageRepository;
+	private final ChatTokenUsageRepository chatTokenUsageRepository;
+	private final ChatMetadataRepository chatMetadataRepository;
+
+	@Transactional
+	public void saveChatData(ChatStreamContext context) {
+		// 빈 응답 체크 로직 등은 여기서 수행
+		if (context.getAnswerBuilder().isEmpty()) {
+			return;
+		}
+
+		try {
+			// 1. ChatMessage 저장
+			ChatMessage chatMessage = ChatMessage.builder()
+				.chatId(context.getChatId())
+				.question(context.getQuestion())
+				.answer(context.getAnswer())
+				.decision(context.getDecision())
+				.build();
+
+			ChatMessage savedMsg = chatMessageRepository.save(chatMessage);
+			String messageId = savedMsg.getId();
+
+			// 2. TokenUsage 저장
+			ChatTokenUsage tokenUsage = ChatTokenUsage.builder()
+				.messageId(messageId)
+				.preset(context.getPreset())
+				.totalTokens(context.getTotalTokens())
+				.build();
+			chatTokenUsageRepository.save(tokenUsage);
+
+			// 3. Metadata 저장
+			ChatMetadata metadata = ChatMetadata.builder()
+				.messageId(messageId)
+				.metadata(context.getMetadataMap())
+				.build();
+			chatMetadataRepository.save(metadata);
+
+		} catch (Exception e) {
+			log.error("채팅 데이터 저장 실패: chatId={}", context.getChatId(), e);
+		}
+	}
+}

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/component/ChatWriter.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/component/ChatWriter.java
@@ -14,6 +14,21 @@ import com.hallachatbot.backend.domain.chat.service.ChatStreamContext;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * <b>대화 데이터 저장 컴포넌트 (Writer)</b>
+ *
+ * <p>
+ * 스트리밍이 종료된 후 {@link ChatStreamContext}에 누적된 데이터를 기반으로
+ * 데이터베이스에 영구 저장하는 역할을 수행
+ * </p>
+ *
+ * <ul>
+ * <li><b>분산 저장:</b> 대화 내용(Chat), 토큰 사용량(Token), 상세 메타데이터(Metadata)를 각각의 컬렉션에 저장</li>
+ * <li><b>트랜잭션:</b> 모든 저장 작업은 하나의 트랜잭션으로 묶여 데이터 일관성을 보장.</li>
+ * </ul>
+ * @author pwk0131
+ */
+
 @Slf4j
 @Component
 @RequiredArgsConstructor

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/component/ChatWriter.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/component/ChatWriter.java
@@ -1,6 +1,7 @@
 package com.hallachatbot.backend.domain.chat.component;
 
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.hallachatbot.backend.domain.chat.entity.ChatMessage;
 import com.hallachatbot.backend.domain.chat.entity.ChatMetadata;
@@ -37,41 +38,37 @@ public class ChatWriter {
 	private final ChatTokenUsageRepository chatTokenUsageRepository;
 	private final ChatMetadataRepository chatMetadataRepository;
 
+	@Transactional
 	public void saveChatData(ChatStreamContext context) {
 		// 빈 응답 체크 로직 등은 여기서 수행
 		if (context.getAnswer().isBlank()) {
 			return;
 		}
 
-		try {
-			// 1. ChatMessage 저장
-			ChatMessage chatMessage = ChatMessage.builder()
-				.chatId(context.getChatId())
-				.question(context.getQuestion())
-				.answer(context.getAnswer())
-				.decision(context.getDecision())
-				.build();
+		// 1. ChatMessage 저장
+		ChatMessage chatMessage = ChatMessage.builder()
+			.chatId(context.getChatId())
+			.question(context.getQuestion())
+			.answer(context.getAnswer())
+			.decision(context.getDecision())
+			.build();
 
-			ChatMessage savedMsg = chatMessageRepository.save(chatMessage);
-			String messageId = savedMsg.getId();
+		ChatMessage savedMsg = chatMessageRepository.save(chatMessage);
+		String messageId = savedMsg.getId();
 
-			// 2. TokenUsage 저장
-			ChatTokenUsage tokenUsage = ChatTokenUsage.builder()
-				.messageId(messageId)
-				.preset(context.getPreset())
-				.totalTokens(context.getTotalTokens())
-				.build();
-			chatTokenUsageRepository.save(tokenUsage);
+		// 2. TokenUsage 저장
+		ChatTokenUsage tokenUsage = ChatTokenUsage.builder()
+			.messageId(messageId)
+			.preset(context.getPreset())
+			.totalTokens(context.getTotalTokens())
+			.build();
+		chatTokenUsageRepository.save(tokenUsage);
 
-			// 3. Metadata 저장
-			ChatMetadata metadata = ChatMetadata.builder()
-				.messageId(messageId)
-				.metadata(context.getMetadataMap())
-				.build();
-			chatMetadataRepository.save(metadata);
-
-		} catch (Exception e) {
-			log.error("채팅 데이터 저장 실패: chatId={}", context.getChatId(), e);
-		}
+		// 3. Metadata 저장
+		ChatMetadata metadata = ChatMetadata.builder()
+			.messageId(messageId)
+			.metadata(context.getMetadataMap())
+			.build();
+		chatMetadataRepository.save(metadata);
 	}
 }

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/component/ChatWriter.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/component/ChatWriter.java
@@ -1,7 +1,6 @@
 package com.hallachatbot.backend.domain.chat.component;
 
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.hallachatbot.backend.domain.chat.entity.ChatMessage;
 import com.hallachatbot.backend.domain.chat.entity.ChatMetadata;
@@ -38,10 +37,9 @@ public class ChatWriter {
 	private final ChatTokenUsageRepository chatTokenUsageRepository;
 	private final ChatMetadataRepository chatMetadataRepository;
 
-	@Transactional
 	public void saveChatData(ChatStreamContext context) {
 		// 빈 응답 체크 로직 등은 여기서 수행
-		if (context.getAnswerBuilder().isEmpty()) {
+		if (context.getAnswer().isBlank()) {
 			return;
 		}
 

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/controller/ChatController.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/controller/ChatController.java
@@ -113,7 +113,7 @@ public class ChatController {
 		}
 
 		// 3. 서비스 호출
-		return chatService.startChat(request, currentChatId, isTampered);
+		return chatService.startChat(request, currentChatId);
 	}
 
 	/**

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/controller/ChatController.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/controller/ChatController.java
@@ -17,8 +17,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.hallachatbot.backend.domain.chat.dto.request.ChatRequest;
 import com.hallachatbot.backend.domain.chat.dto.response.ChatHistoryResponse;
-import com.hallachatbot.backend.domain.chat.entity.ChatMessage;
-import com.hallachatbot.backend.domain.chat.repository.ChatMessageRepository;
 import com.hallachatbot.backend.domain.chat.service.ChatService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -52,7 +50,6 @@ import reactor.core.publisher.Flux;
 public class ChatController {
 
 	private final ChatService chatService;
-	private final ChatMessageRepository chatMessageRepository;
 
 	/**
 	 * 채팅 스트리밍 엔드포인트
@@ -75,6 +72,7 @@ public class ChatController {
 		@ApiResponse(responseCode = "400", description = "잘못된 요청 (입력값 누락 등)"),
 		@ApiResponse(responseCode = "500", description = "서버 내부 오류")
 	})
+
 	@PostMapping
 	public Flux<ServerSentEvent<String>> chat(
 		@Parameter(description = "채팅 요청 정보 (질문, 언어 등)", required = true)
@@ -87,21 +85,16 @@ public class ChatController {
 	) {
 		String currentChatId;
 		boolean isNewUser = false;
-		boolean isTampered = false;
 
 		// 1. 쿠키 검증 및 ID 결정
 		if (cookieChatId != null && ObjectId.isValid(cookieChatId)) {
 			currentChatId = cookieChatId;
 		} else {
-			if (cookieChatId != null) {
-				log.warn("잘못된 쿠키 감지됨: {}", cookieChatId);
-				isTampered = true;
-			}
 			currentChatId = new ObjectId().toHexString();
 			isNewUser = true;
 		}
 
-		// 2. 새로운 유저(또는 변조됨)라면 쿠키 재발급
+		// 2. 새로운 유저라면 쿠키 재발급
 		if (isNewUser) {
 			ResponseCookie cookie = ResponseCookie.from("chatId", currentChatId)
 				.maxAge(Duration.ofSeconds(86400))
@@ -141,16 +134,6 @@ public class ChatController {
 		if (cookieChatId == null || !ObjectId.isValid(cookieChatId)) {
 			return Collections.emptyList();
 		}
-
-		List<ChatMessage> rawHistory = chatMessageRepository.findTop6ByChatIdOrderByCreatedDateDesc(cookieChatId);
-
-		Collections.reverse(rawHistory);
-
-		return rawHistory.stream()
-			.flatMap(msg -> java.util.stream.Stream.of(
-				ChatHistoryResponse.user(msg.getQuestion()),
-				ChatHistoryResponse.assistant(msg.getAnswer())
-			))
-			.toList();
+		return chatService.getChatHistory(cookieChatId);
 	}
 }

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/controller/ChatController.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/controller/ChatController.java
@@ -27,16 +27,22 @@ import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Flux;
 
 /**
- * 채팅 도메인 컨트롤러
+ * <b>채팅 도메인 API 컨트롤러</b>
  *
  * <p>
- * 엔드포인트: /api/chat
+ * 클라이언트의 채팅 요청을 처리하는 진입점.
+ * AI 모델과의 실시간 대화 스트리밍(SSE) 및 과거 대화 이력 조회 기능을 제공함.
  * </p>
+ *
+ * <ul>
+ * <li>Base URL: {@code /api/chat}</li>
+ * <li>주요 기능: 메시지 전송(Streaming), 히스토리 조회</li>
+ * </ul>
  *
  * @author pwk0131
  */
 @Slf4j
-@Tag(name = "Chat API", description = "AI 챗봇 대화 및 히스토리 관리")
+@Tag(name = "Chat API", description = "AI 챗봇 대화 수행 및 히스토리 관리")
 @RestController
 @RequestMapping("/api/chat")
 @RequiredArgsConstructor
@@ -45,15 +51,17 @@ public class ChatController {
 	private final ChatService chatService;
 
 	/**
-	 * 채팅 스트리밍 엔드포인트
+	 * <b>채팅 메시지 전송 및 답변 스트리밍</b>
 	 *
 	 * <p>
-	 * POST /api/chat<br>
-	 * 쿠키(chatId)를 확인하여 세션을 관리하고 AI 응답을 SSE로 반환
+	 * 사용자의 질문을 입력받아 AI 서비스의 답변을 Server-Sent Events(SSE) 방식으로 실시간 스트리밍함.<br>
+	 * {@link ChatSession} 어노테이션을 통해 쿠키에서 세션 ID를 추출하거나 신규 발급하여 대화 맥락을 유지함.
 	 * </p>
 	 *
-	 * @param request 사용자 요청 DTO
-	 * @return SSE 스트림
+	 * @param request 사용자 질문 및 언어 설정이 포함된 요청 DTO
+	 * @param chatId  사용자 식별 세션 ID (쿠키에서 자동 주입, Swagger 숨김 처리)
+	 * @return AI 답변 데이터 스트림 (Flux&lt;ServerSentEvent&gt;)
+	 * @see com.hallachatbot.backend.global.resolver.ChatSessionArgumentResolver
 	 */
 	@Operation(summary = "채팅 답변 스트리밍", description = "사용자의 질문을 입력받아 AI 답변을 SSE(Server-Sent Events)로 실시간 스트리밍합니다.")
 	@ApiResponses(value = {
@@ -61,10 +69,11 @@ public class ChatController {
 			responseCode = "200",
 			description = "성공 (스트리밍 시작)",
 			content = @Content(mediaType = "text/event-stream",
-				schema = @Schema(implementation = ServerSentEvent.class))),
-		@ApiResponse(responseCode = "400", description = "잘못된 요청 (입력값 누락 등)"),
-		@ApiResponse(responseCode = "429", description = "요청 한도 초과 (일일/월간 사용량 제한)"),
-		@ApiResponse(responseCode = "500", description = "서버 내부 오류")
+				schema = @Schema(implementation = ServerSentEvent.class))
+		),
+		@ApiResponse(responseCode = "400", description = "잘못된 요청 (필수 값 누락, 유효성 검증 실패)"),
+		@ApiResponse(responseCode = "429", description = "요청 한도 초과"),
+		@ApiResponse(responseCode = "500", description = "서버 내부 오류 또는 AI 서비스 연동 실패")
 	})
 	@PostMapping
 	public Flux<ServerSentEvent<String>> chat(
@@ -77,14 +86,15 @@ public class ChatController {
 	}
 
 	/**
-	 * 대화 히스토리 조회 엔드포인트
+	 * <b>대화 히스토리 조회</b>
 	 *
 	 * <p>
-	 * GET /api/chat/history<br>
-	 * 현재 쿠키의 chatId를 기반으로 최근 대화 내역 반환
+	 * 현재 세션(Cookie: chatId)에 해당하는 최근 대화 내역을 조회함.<br>
+	 * 기본적으로 최근 6건(User-Assistant 쌍)의 대화를 최신순으로 반환함.
 	 * </p>
 	 *
-	 * @return 대화 내역 리스트 (user/assistant 쌍)
+	 * @param chatId 사용자 식별 세션 ID (쿠키에서 자동 주입, Swagger 숨김 처리)
+	 * @return 대화 내역 리스트 (Role, Content 구조)
 	 */
 	@Operation(summary = "대화 히스토리 조회", description = "쿠키에 저장된 chatId를 기반으로 최근 대화 내역을 조회합니다.")
 	@ApiResponses(value = {

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/controller/ChatController.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/controller/ChatController.java
@@ -97,8 +97,7 @@ public class ChatController {
 	 */
 	@Operation(summary = "대화 히스토리 조회", description = "쿠키에 저장된 chatId를 기반으로 최근 대화 내역을 조회합니다.")
 	@ApiResponses(value = {
-		@ApiResponse(responseCode = "200", description = "조회 성공"),
-		@ApiResponse(responseCode = "401", description = "인증 실패 (쿠키 없음)")
+		@ApiResponse(responseCode = "200", description = "조회 성공")
 	})
 
 	@GetMapping("/history")

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/controller/ChatController.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/controller/ChatController.java
@@ -69,8 +69,7 @@ public class ChatController {
 			responseCode = "200",
 			description = "성공 (스트리밍 시작)",
 			content = @Content(mediaType = "text/event-stream",
-				schema = @Schema(implementation = ServerSentEvent.class))
-		),
+				schema = @Schema(implementation = ServerSentEvent.class))),
 		@ApiResponse(responseCode = "400", description = "잘못된 요청 (필수 값 누락, 유효성 검증 실패)"),
 		@ApiResponse(responseCode = "429", description = "요청 한도 초과"),
 		@ApiResponse(responseCode = "500", description = "서버 내부 오류 또는 AI 서비스 연동 실패")

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/controller/ChatController.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/controller/ChatController.java
@@ -57,17 +57,21 @@ public class ChatController {
 	 */
 	@Operation(summary = "채팅 답변 스트리밍", description = "사용자의 질문을 입력받아 AI 답변을 SSE(Server-Sent Events)로 실시간 스트리밍합니다.")
 	@ApiResponses(value = {
-		@ApiResponse(responseCode = "200", description = "성공 (스트리밍 시작)",
+		@ApiResponse(
+			responseCode = "200",
+			description = "성공 (스트리밍 시작)",
 			content = @Content(mediaType = "text/event-stream",
-				schema = @Schema(implementation = ServerSentEvent.class))),
+				schema = @Schema(implementation = ServerSentEvent.class))
+		),
 		@ApiResponse(responseCode = "400", description = "잘못된 요청 (입력값 누락 등)"),
+		@ApiResponse(responseCode = "429", description = "요청 한도 초과 (일일/월간 사용량 제한)"),
 		@ApiResponse(responseCode = "500", description = "서버 내부 오류")
 	})
-
 	@PostMapping
 	public Flux<ServerSentEvent<String>> chat(
-		@Parameter(description = "채팅 요청 정보", required = true)
+		@Parameter(description = "채팅 요청 정보 (질문, 모델 설정 등)", required = true)
 		@Valid @RequestBody ChatRequest request,
+		@Parameter(hidden = true)
 		@ChatSession String chatId
 	) {
 		return chatService.startChat(request, chatId);
@@ -91,6 +95,7 @@ public class ChatController {
 
 	@GetMapping("/history")
 	public List<ChatHistoryResponse> getHistory(
+		@Parameter(hidden = true)
 		@ChatSession String chatId
 	) {
 		return chatService.getChatHistory(chatId);

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/controller/ChatController.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/controller/ChatController.java
@@ -61,8 +61,7 @@ public class ChatController {
 			responseCode = "200",
 			description = "성공 (스트리밍 시작)",
 			content = @Content(mediaType = "text/event-stream",
-				schema = @Schema(implementation = ServerSentEvent.class))
-		),
+				schema = @Schema(implementation = ServerSentEvent.class))),
 		@ApiResponse(responseCode = "400", description = "잘못된 요청 (입력값 누락 등)"),
 		@ApiResponse(responseCode = "429", description = "요청 한도 초과 (일일/월간 사용량 제한)"),
 		@ApiResponse(responseCode = "500", description = "서버 내부 오류")

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/controller/ChatController.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/controller/ChatController.java
@@ -1,14 +1,8 @@
 package com.hallachatbot.backend.domain.chat.controller;
 
-import java.time.Duration;
-import java.util.Collections;
 import java.util.List;
 
-import org.bson.types.ObjectId;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseCookie;
 import org.springframework.http.codec.ServerSentEvent;
-import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -18,16 +12,15 @@ import org.springframework.web.bind.annotation.RestController;
 import com.hallachatbot.backend.domain.chat.dto.request.ChatRequest;
 import com.hallachatbot.backend.domain.chat.dto.response.ChatHistoryResponse;
 import com.hallachatbot.backend.domain.chat.service.ChatService;
+import com.hallachatbot.backend.global.annotation.ChatSession;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -60,8 +53,6 @@ public class ChatController {
 	 * </p>
 	 *
 	 * @param request 사용자 요청 DTO
-	 * @param cookieChatId 쿠키에 저장된 chatId (없을 수 있음)
-	 * @param response HTTP 응답 객체 (쿠키 설정용)
 	 * @return SSE 스트림
 	 */
 	@Operation(summary = "채팅 답변 스트리밍", description = "사용자의 질문을 입력받아 AI 답변을 SSE(Server-Sent Events)로 실시간 스트리밍합니다.")
@@ -75,38 +66,11 @@ public class ChatController {
 
 	@PostMapping
 	public Flux<ServerSentEvent<String>> chat(
-		@Parameter(description = "채팅 요청 정보 (질문, 언어 등)", required = true)
+		@Parameter(description = "채팅 요청 정보", required = true)
 		@Valid @RequestBody ChatRequest request,
-
-		@Parameter(description = "사용자 식별 쿠키 (chatId)", in = ParameterIn.COOKIE, required = false)
-		@CookieValue(value = "chatId", required = false) String cookieChatId,
-
-		HttpServletResponse response
+		@ChatSession String chatId
 	) {
-		String currentChatId;
-		boolean isNewUser = false;
-
-		// 1. 쿠키 검증 및 ID 결정
-		if (cookieChatId != null && ObjectId.isValid(cookieChatId)) {
-			currentChatId = cookieChatId;
-		} else {
-			currentChatId = new ObjectId().toHexString();
-			isNewUser = true;
-		}
-
-		// 2. 새로운 유저라면 쿠키 재발급
-		if (isNewUser) {
-			ResponseCookie cookie = ResponseCookie.from("chatId", currentChatId)
-				.maxAge(Duration.ofSeconds(86400))
-				.secure(true)
-				.httpOnly(false)
-				.path("/")
-				.build();
-			response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
-		}
-
-		// 3. 서비스 호출
-		return chatService.startChat(request, currentChatId);
+		return chatService.startChat(request, chatId);
 	}
 
 	/**
@@ -117,10 +81,9 @@ public class ChatController {
 	 * 현재 쿠키의 chatId를 기반으로 최근 대화 내역 반환
 	 * </p>
 	 *
-	 * @param cookieChatId 쿠키에 저장된 chatId
 	 * @return 대화 내역 리스트 (user/assistant 쌍)
 	 */
-	@Operation(summary = "대화 히스토리 조회", description = "쿠키에 저장된 chatId를 기반으로 최근 대화 내역(최대 6개)을 조회합니다.")
+	@Operation(summary = "대화 히스토리 조회", description = "쿠키에 저장된 chatId를 기반으로 최근 대화 내역을 조회합니다.")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "조회 성공"),
 		@ApiResponse(responseCode = "401", description = "인증 실패 (쿠키 없음)")
@@ -128,12 +91,8 @@ public class ChatController {
 
 	@GetMapping("/history")
 	public List<ChatHistoryResponse> getHistory(
-		@Parameter(description = "사용자 식별 쿠키 (chatId)", in = ParameterIn.COOKIE, required = false)
-		@CookieValue(value = "chatId", required = false) String cookieChatId
+		@ChatSession String chatId
 	) {
-		if (cookieChatId == null || !ObjectId.isValid(cookieChatId)) {
-			return Collections.emptyList();
-		}
-		return chatService.getChatHistory(cookieChatId);
+		return chatService.getChatHistory(chatId);
 	}
 }

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/dto/request/ChatRequest.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/dto/request/ChatRequest.java
@@ -35,11 +35,6 @@ public class ChatRequest {
 	@NotNull(message = "언어 설정은 필수입니다.")
 	private Language language;
 
-	/**
-	 * 클라이언트가 보낸 chatId, 보통 쿠키로 처리하므로 바디에서는 잘 안쓰일 수 있음
-	 */
-	private String chatId;
-
 	public enum Language {
 		KOR, ENG, VNM, CHN, UZB, MNG, IDN
 	}

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/dto/request/ChatRequest.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/dto/request/ChatRequest.java
@@ -5,8 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * 챗봇 대화 요청 DTO
@@ -17,24 +15,15 @@ import lombok.NoArgsConstructor;
  *
  * @author pwk0131
  */
-@Getter
-@NoArgsConstructor
-public class ChatRequest {
-
-	/**
-	 * 사용자 입력 질문
-	 */
+public record ChatRequest(
 	@NotBlank(message = "질문은 비어있을 수 없습니다.")
 	@Size(max = 300, message = "질문은 300자를 넘을 수 없습니다.")
 	@JsonProperty("user_input")
-	private String userInput;
+	String userInput,
 
-	/**
-	 * 답변 언어 설정
-	 */
 	@NotNull(message = "언어 설정은 필수입니다.")
-	private Language language;
-
+	Language language
+) {
 	public enum Language {
 		KOR, ENG, VNM, CHN, UZB, MNG, IDN
 	}

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/dto/request/ChatRequest.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/dto/request/ChatRequest.java
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 /**
- * 챗봇 대화 요청 DTO
+ * <b>챗봇 대화 요청 DTO</b>
  *
  * <p>
  * 클라이언트로부터 전달받는 사용자 질문 및 설정 정보

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/dto/response/ChatHistoryResponse.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/dto/response/ChatHistoryResponse.java
@@ -1,13 +1,15 @@
 package com.hallachatbot.backend.domain.chat.dto.response;
 
 /**
- * 채팅 히스토리 응답 DTO
+ * <b>채팅 히스토리 응답 DTO</b>
  *
  * <p>
- * 클라이언트(UI)에 과거 대화 내역을 전달하기 위한 객체<br>
- * OpenAI API 포맷과 유사하게 role(역할)과 content(내용)으로 구성됨
+ * 클라이언트(UI) 렌더링 및 AI 모델의 문맥 주입을 위해 사용되는 과거 대화 객체.
+ * OpenAI Chat Completion API의 Message 구조(role, content)를 준수함.
  * </p>
  *
+ * @param role    메시지 발화자 역할 (예: "user", "assistant")
+ * @param content 메시지 본문 내용
  * @author pwk0131
  */
 public record ChatHistoryResponse(

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/dto/response/ChatHistoryResponse.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/dto/response/ChatHistoryResponse.java
@@ -1,9 +1,5 @@
 package com.hallachatbot.backend.domain.chat.dto.response;
 
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
 /**
  * 채팅 히스토리 응답 DTO
  *
@@ -14,26 +10,10 @@ import lombok.NoArgsConstructor;
  *
  * @author pwk0131
  */
-@Getter
-@NoArgsConstructor
-public class ChatHistoryResponse {
-
-	/**
-	 * 역할 (user 또는 assistant)
-	 */
-	private String role;
-
-	/**
-	 * 대화 내용
-	 */
-	private String content;
-
-	@Builder
-	public ChatHistoryResponse(String role, String content) {
-		this.role = role;
-		this.content = content;
-	}
-
+public record ChatHistoryResponse(
+	String role,
+	String content
+) {
 	/**
 	 * 사용자(User) 메시지 생성 편의 메서드
 	 */

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/entity/ChatMessage.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/entity/ChatMessage.java
@@ -14,12 +14,17 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 /**
- * 챗봇 대화 내용 저장 엔티티
+ * <b>챗봇 대화 메시지 엔티티</b>
  *
  * <p>
- * 컬렉션 : {@code chat}<br>
- * 사용자 질문, AI 답변, RAG 결정 사유 등을 저장함
+ * 사용자와 AI 간의 질의응답 내용을 저장하는 메인 문서.
+ * 질문(question), 답변(answer), 그리고 답변 생성에 대한 근거(decision)를 포함.
  * </p>
+ *
+ * <ul>
+ * <li>Collection Name: {@code chat}</li>
+ * </ul>
+ *
  * @author pwk0131
  */
 @Getter
@@ -53,7 +58,10 @@ public class ChatMessage {
 	private String decision;
 
 	/**
-	 * 사용자 세션 ID (쿠키의 chatId)
+	 * 사용자 세션 식별자 (Cookie의 chatId)
+	 * <p>
+	 * 특정 사용자의 대화 흐름을 그룹화하기 위한 외래 키 역할
+	 * </p>
 	 */
 	@Field(name = "chatId", targetType = FieldType.OBJECT_ID)
 	private String chatId;

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/entity/ChatMetadata.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/entity/ChatMetadata.java
@@ -15,12 +15,17 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 /**
- * 대화 메타데이터 엔티티
+ * <b>대화 상세 메타데이터 엔티티</b>
  *
  * <p>
- * 컬렉션 : {@code metadata}<br>
- * AI 서비스로부터 반환된 원본 메타데이터 상세 정보를 저장 (디버깅 및 분석용)
+ * AI 서비스로부터 반환된 원본 메타데이터(JSON)를 보관하는 문서.
+ * 디버깅, 품질 분석, 모델 성능 모니터링 목적으로 사용.
  * </p>
+ *
+ * <ul>
+ * <li>Collection Name: {@code metadata}</li>
+ * <li>Relation: {@link ChatMessage}와 1:1 대응</li>
+ * </ul>
  *
  * @author pwk0131
  */
@@ -40,15 +45,18 @@ public class ChatMetadata {
 	private LocalDateTime createdDate;
 
 	/**
-	 * 연관된 메시지 ID (ChatMessage의 _id)
+	 * 연관된 대화 메시지 ID
+	 * <p>
+	 * {@link ChatMessage}의 PK(_id)를 참조
+	 * </p>
 	 */
 	@Field(name = "chatId", targetType = FieldType.OBJECT_ID)
 	private String messageId;
 
 	/**
-	 * 메타데이터 원본 (JSON 객체)
+	 * 메타데이터 원본 (Key-Value)
 	 * <p>
-	 * 구조가 가변적일 수 있으므로 Map으로 매핑
+	 * AI 파이프라인의 단계별 처리 결과 및 디버그 정보를 포함
 	 * </p>
 	 */
 	private Map<String, Object> metadata;

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/entity/ChatTokenUsage.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/entity/ChatTokenUsage.java
@@ -14,12 +14,17 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 /**
- * 대화별 토큰 사용량 관리 엔티티
+ * <b>토큰 사용량 기록 엔티티</b>
  *
  * <p>
- * 컬렉션 : {@code token}<br>
- * 특정 대화({@link ChatMessage}) 발생 시 소모된 토큰 정보 저장
+ * 대화 생성 시 소모된 토큰(Token) 수와 사용된 모델(Preset) 정보를 저장.
+ * 비용 산정 및 사용량 통계 분석에 활용.
  * </p>
+ *
+ * <ul>
+ * <li>Collection Name: {@code token}</li>
+ * <li>Relation: {@link ChatMessage}와 1:1 대응</li>
+ * </ul>
  *
  * @author pwk0131
  */
@@ -39,21 +44,22 @@ public class ChatTokenUsage {
 	private LocalDateTime createdDate;
 
 	/**
-	 * 연관된 메시지 ID (ChatMessage의 _id)
+	 * 연관된 대화 메시지 ID
 	 * <p>
-	 * 주의: Python 코드에서 message_id를 'chatId' 필드명으로 저장했음.
+	 * {@link ChatMessage}의 PK(_id)를 참조.<br>
+	 * <b>주의:</b> 레거시 데이터와의 호환성을 위해 DB 필드명은 'chatId'로 저장됨.
 	 * </p>
 	 */
 	@Field(name = "chatId", targetType = FieldType.OBJECT_ID)
 	private String messageId;
 
 	/**
-	 * 사용된 LLM 프리셋 (모델명 등)
+	 * 사용된 LLM 모델 프리셋 (예: gpt-4o, claude-3)
 	 */
 	private String preset;
 
 	/**
-	 * 총 사용 토큰 수
+	 * 총 소모 토큰 수 (입력 + 출력)
 	 */
 	private Integer totalTokens;
 

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/repository/ChatMessageRepository.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/repository/ChatMessageRepository.java
@@ -8,8 +8,7 @@ import org.springframework.stereotype.Repository;
 import com.hallachatbot.backend.domain.chat.entity.ChatMessage;
 
 /**
- * ChatMessage 리포지토리
- *
+ * <b>ChatMessage 리포지토리</b>
  * <p>
  * MongoDB 'chat' 컬렉션에 대한 CRUD 및 쿼리 메서드 제공
  * </p>

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/repository/ChatMetadataRepository.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/repository/ChatMetadataRepository.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Repository;
 import com.hallachatbot.backend.domain.chat.entity.ChatMetadata;
 
 /**
- * ChatMetadata 리포지토리
+ * <b>ChatMetadata 리포지토리</b>
  *
  * <p>
  * MongoDB 'metadata' 컬렉션 접근용<br>

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/repository/ChatTokenUsageRepository.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/repository/ChatTokenUsageRepository.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Repository;
 import com.hallachatbot.backend.domain.chat.entity.ChatTokenUsage;
 
 /**
- * ChatTokenUsage 리포지토리
+ * <b>ChatTokenUsage 리포지토리</b>
  *
  * <p>
  * MongoDB 'token' 컬렉션 접근용<br>

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/service/ChatService.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/service/ChatService.java
@@ -71,7 +71,7 @@ public class ChatService {
 		List<ChatHistoryResponse> history = getChatHistory(chatId);
 
 		// 스트림 동안 상태(답변, 메타데이터 등)를 누적할 객체 생성
-		ChatStreamContext context = new ChatStreamContext(chatId, request.getUserInput());
+		ChatStreamContext context = new ChatStreamContext(chatId, request.userInput());
 
 		// 3. AI 서비스 호출 및 스트리밍 변환
 		Flux<ServerSentEvent<String>> eventFlux = aiServiceClient.streamChat(request, history)

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/service/ChatService.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/service/ChatService.java
@@ -55,10 +55,9 @@ public class ChatService {
 	 *
 	 * @param request 사용자 요청 DTO
 	 * @param chatId 세션 ID (쿠키)
-	 * @param isTampered 쿠키 변조 여부
 	 * @return SSE 스트림
 	 */
-	public Flux<ServerSentEvent<String>> startChat(ChatRequest request, String chatId, boolean isTampered) {
+	public Flux<ServerSentEvent<String>> startChat(ChatRequest request, String chatId) {
 		// 1. 비용 한도 확인 (예외 발생 시 GlobalExceptionHandler 처리)
 		usageService.checkLlmUsage();
 
@@ -75,7 +74,7 @@ public class ChatService {
 			.doOnComplete(() -> saveChatData(state)); // 스트림 완료 시 DB 저장
 
 		// 4. 초기 이벤트 주입 (Metadata, Warning)
-		return injectInitialEvents(eventFlux, chatId, isTampered);
+		return injectInitialEvents(eventFlux, chatId);
 	}
 
 	/**
@@ -170,21 +169,12 @@ public class ChatService {
 
 	private Flux<ServerSentEvent<String>> injectInitialEvents(
 		Flux<ServerSentEvent<String>> mainFlux,
-		String chatId,
-		boolean isTampered
+		String chatId
 	) {
 		// 메타데이터 이벤트 (chatId 전송용)
 		ServerSentEvent<String> metaEvent = createSseEvent("metadata", Map.of("chatId", chatId), null);
 
 		Flux<ServerSentEvent<String>> prefixFlux = Flux.just(metaEvent);
-
-		// 쿠키 변조 경고 메시지
-		if (isTampered) {
-			String warningMsg = "유효하지 않은 쿠키가 감지되어 새로운 대화가 시작되었습니다. "
-				+ "쿠키를 임의로 변경하면 이전 대화를 기억하지 못해 응답 품질이 떨어질 수 있습니다.\n\n";
-			ServerSentEvent<String> warningEvent = createSseEvent("delta", null, warningMsg);
-			prefixFlux = prefixFlux.concatWith(Flux.just(warningEvent));
-		}
 
 		return prefixFlux.concatWith(mainFlux);
 	}

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/service/ChatService.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/service/ChatService.java
@@ -8,8 +8,6 @@ import java.util.Map;
 import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.stereotype.Service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hallachatbot.backend.domain.chat.dto.request.ChatRequest;
 import com.hallachatbot.backend.domain.chat.dto.response.ChatHistoryResponse;
 import com.hallachatbot.backend.domain.chat.entity.ChatMessage;
@@ -21,6 +19,7 @@ import com.hallachatbot.backend.domain.chat.repository.ChatTokenUsageRepository;
 import com.hallachatbot.backend.domain.usage.service.UsageService;
 import com.hallachatbot.backend.global.client.dto.AiServiceResponse;
 import com.hallachatbot.backend.global.client.service.AiServiceClient;
+import com.hallachatbot.backend.global.sse.SseEventFactory;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -47,7 +46,7 @@ public class ChatService {
 	private final ChatMessageRepository chatMessageRepository;
 	private final ChatTokenUsageRepository chatTokenUsageRepository;
 	private final ChatMetadataRepository chatMetadataRepository;
-	private final ObjectMapper objectMapper;
+	private final SseEventFactory sseEventFactory;
 
 	/**
 	 * 채팅 스트리밍 시작
@@ -57,7 +56,7 @@ public class ChatService {
 	 * @return SSE 스트림
 	 */
 	public Flux<ServerSentEvent<String>> startChat(ChatRequest request, String chatId) {
-		// 1. 비용 한도 확인 (예외 발생 시 GlobalExceptionHandler 처리)
+		// 1. 비용 한도 확인
 		usageService.checkLlmUsage();
 
 		// 2. 대화 히스토리 조회
@@ -95,7 +94,7 @@ public class ChatService {
 	}
 
 	/**
-	 * AI 응답 하나를 처리하고 SSE 이벤트로 변환
+	 * AI 응답 처리 및 SSeEventFactory를 이용한 이벤트 변환
 	 */
 	private ServerSentEvent<String> processAiResponse(AiServiceResponse response, StreamState state) {
 		String type = response.getType();
@@ -105,21 +104,23 @@ public class ChatService {
 			if (content != null) {
 				state.appendAnswer(content);
 			}
-			return createSseEvent("delta", null, content);
+			return sseEventFactory.createDelta(content);
+
 		} else if ("metadata".equals(type)) {
 			Map<String, Object> data = response.getData();
 			state.updateMetadata(data);
 
-			// 클라이언트에 보낼 때는 chatId를 포함
+			// 클라이언트 전송용 데이터 가공 (chatId 추가)
 			Map<String, Object> eventData = data != null ? new HashMap<>(data) : new HashMap<>();
 			eventData.put("chatId", state.getChatId());
 
-			return createSseEvent("metadata", eventData, null);
+			return sseEventFactory.createMetadata(eventData);
+
 		} else if ("error".equals(type)) {
-			return createSseEvent("error", response.getData(), response.getMessage());
+			return sseEventFactory.createError(response.getData(), response.getMessage());
 		}
 
-		return ServerSentEvent.<String>builder().comment("keep-alive").build();
+		return sseEventFactory.createKeepAlive();
 	}
 
 	/**
@@ -185,38 +186,9 @@ public class ChatService {
 			.toList();
 	}
 
-	private Flux<ServerSentEvent<String>> injectInitialEvents(
-		Flux<ServerSentEvent<String>> mainFlux,
-		String chatId
-	) {
-		// 메타데이터 이벤트 (chatId 전송용)
-		ServerSentEvent<String> metaEvent = createSseEvent("metadata", Map.of("chatId", chatId), null);
-
-		Flux<ServerSentEvent<String>> prefixFlux = Flux.just(metaEvent);
-
-		return prefixFlux.concatWith(mainFlux);
-	}
-
-	/**
-	 * SSE 이벤트 생성 유틸 (JSON 문자열 직렬화 포함)
-	 */
-	private ServerSentEvent<String> createSseEvent(String type, Map<String, Object> data, String content) {
-		Map<String, Object> jsonMap = new HashMap<>();
-		jsonMap.put("type", type);
-		if (data != null) {
-			jsonMap.put("data", data);
-		}
-		if (content != null) {
-			jsonMap.put("content", content);
-		}
-
-		try {
-			String jsonString = objectMapper.writeValueAsString(jsonMap);
-			return ServerSentEvent.builder(jsonString).build();
-		} catch (JsonProcessingException e) {
-			log.error("SSE JSON 직렬화 오류", e);
-			return ServerSentEvent.builder("").build();
-		}
+	private Flux<ServerSentEvent<String>> injectInitialEvents(Flux<ServerSentEvent<String>> mainFlux, String chatId) {
+		ServerSentEvent<String> metaEvent = sseEventFactory.createMetadata(Map.of("chatId", chatId));
+		return Flux.just(metaEvent).concatWith(mainFlux);
 	}
 
 	/**

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/service/ChatService.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/service/ChatService.java
@@ -22,11 +22,16 @@ import reactor.core.publisher.Flux;
 import reactor.core.scheduler.Schedulers;
 
 /**
- * 챗봇 서비스 로직
+ * <b>채팅 도메인 메인 서비스</b>
  *
  * <p>
- * 비용 확인 -> 히스토리 조회 -> AI 요청 -> 스트리밍 -> DB 저장
+ * 사용자 요청부터 AI 응답 스트리밍, 그리고 데이터 저장까지의 전체 흐름(Flow)을 조율
  * </p>
+ *
+ * <ul>
+ * <li><b>흐름 제어:</b> 비용 확인 &rarr; 히스토리 조회 &rarr; AI 요청 &rarr; 응답 핸들링 &rarr; 결과 저장</li>
+ * <li><b>비동기 처리:</b> Reactor(Flux)를 활용한 논블로킹 스트리밍을 구현하며, DB 저장은 스트림 완료 후 별도 스레드에서 수행</li>
+ * </ul>
  *
  * @author pwk0131
  */
@@ -45,11 +50,18 @@ public class ChatService {
 	private final ChatStreamErrorHandler chatStreamErrorHandler;
 
 	/**
-	 * 채팅 스트리밍 시작
+	 * 채팅 프로세스 시작 (스트리밍)
 	 *
-	 * @param request 사용자 요청 DTO
-	 * @param chatId 세션 ID (쿠키)
-	 * @return SSE 스트림
+	 * <p>
+	 * 1. 월간 사용량 한도를 체크<br>
+	 * 2. 현재 세션의 과거 대화 내역을 가져와 문맥을 형성<br>
+	 * 3. AI 서비스에 요청을 보내고 실시간 응답(SSE) 스트림을 생성<br>
+	 * 4. 스트리밍이 정상적으로 완료되면, 수집된 대화 데이터를 DB에 비동기로 저장
+	 * </p>
+	 *
+	 * @param request 사용자 질문 및 설정이 담긴 요청 객체
+	 * @param chatId 사용자 식별을 위한 세션 ID (쿠키)
+	 * @return 클라이언트로 전송될 Server-Sent Events 스트림
 	 */
 	public Flux<ServerSentEvent<String>> startChat(ChatRequest request, String chatId) {
 		// 1. 비용 한도 확인
@@ -67,7 +79,7 @@ public class ChatService {
 			.onErrorResume(chatStreamErrorHandler::handleStreamError)
 			.doOnComplete(() -> {
 				// 저장 로직 비동기 실행
-				if (context.hasAnswer()) { // 답변이 조금이라도 생성되었을 때만 저장
+				if (context.hasAnswer()) {
 					Flux.just(context)
 						.publishOn(Schedulers.boundedElastic())
 						.subscribe(chatWriter::saveChatData);
@@ -82,7 +94,7 @@ public class ChatService {
 	 * 대화 히스토리 조회
 	 *
 	 * <p>
-	 * 주어진 chatId에 해당하는 최근 대화 내역(최대 6개)을 조회하여 반환<br>
+	 * 주어진 chatId에 해당하는 최근 대화 내역(6개)을 조회하여 반환<br>
 	 * 컨트롤러의 히스토리 조회 API와 내부 AI 요청 시 대화 문맥 제공용으로 공통 사용
 	 * </p>
 	 *

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/service/ChatService.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/service/ChatService.java
@@ -19,8 +19,8 @@ import com.hallachatbot.backend.domain.chat.repository.ChatMessageRepository;
 import com.hallachatbot.backend.domain.chat.repository.ChatMetadataRepository;
 import com.hallachatbot.backend.domain.chat.repository.ChatTokenUsageRepository;
 import com.hallachatbot.backend.domain.usage.service.UsageService;
-import com.hallachatbot.backend.global.client.AiServiceClient;
 import com.hallachatbot.backend.global.client.dto.AiServiceResponse;
+import com.hallachatbot.backend.global.client.service.AiServiceClient;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/service/ChatService.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/service/ChatService.java
@@ -1,27 +1,20 @@
 package com.hallachatbot.backend.domain.chat.service;
 
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.stereotype.Service;
 
+import com.hallachatbot.backend.domain.chat.component.ChatReader;
+import com.hallachatbot.backend.domain.chat.component.ChatStreamHandler;
+import com.hallachatbot.backend.domain.chat.component.ChatWriter;
 import com.hallachatbot.backend.domain.chat.dto.request.ChatRequest;
 import com.hallachatbot.backend.domain.chat.dto.response.ChatHistoryResponse;
-import com.hallachatbot.backend.domain.chat.entity.ChatMessage;
-import com.hallachatbot.backend.domain.chat.entity.ChatMetadata;
-import com.hallachatbot.backend.domain.chat.entity.ChatTokenUsage;
-import com.hallachatbot.backend.domain.chat.repository.ChatMessageRepository;
-import com.hallachatbot.backend.domain.chat.repository.ChatMetadataRepository;
-import com.hallachatbot.backend.domain.chat.repository.ChatTokenUsageRepository;
 import com.hallachatbot.backend.domain.usage.service.UsageService;
-import com.hallachatbot.backend.global.client.dto.AiServiceResponse;
 import com.hallachatbot.backend.global.client.service.AiServiceClient;
 import com.hallachatbot.backend.global.sse.SseEventFactory;
 
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Flux;
@@ -43,10 +36,11 @@ public class ChatService {
 
 	private final UsageService usageService;
 	private final AiServiceClient aiServiceClient;
-	private final ChatMessageRepository chatMessageRepository;
-	private final ChatTokenUsageRepository chatTokenUsageRepository;
-	private final ChatMetadataRepository chatMetadataRepository;
 	private final SseEventFactory sseEventFactory;
+
+	private final ChatReader chatReader;
+	private final ChatWriter chatWriter;
+	private final ChatStreamHandler chatStreamHandler;
 
 	/**
 	 * 채팅 스트리밍 시작
@@ -63,12 +57,17 @@ public class ChatService {
 		List<ChatHistoryResponse> history = getChatHistory(chatId);
 
 		// 스트림 동안 상태(답변, 메타데이터 등)를 누적할 객체 생성
-		StreamState state = new StreamState(chatId, request.getUserInput());
+		ChatStreamContext context = new ChatStreamContext(chatId, request.getUserInput());
 
 		// 3. AI 서비스 호출 및 스트리밍 변환
 		Flux<ServerSentEvent<String>> eventFlux = aiServiceClient.streamChat(request, history)
-			.map(aiResponse -> processAiResponse(aiResponse, state))
-			.doOnComplete(() -> saveChatData(state)); // 스트림 완료 시 DB 저장
+			.map(aiResponse -> chatStreamHandler.processAiResponse(aiResponse, context))
+			.doOnComplete(() -> {
+				// 저장 로직 비동기 실행
+				Flux.just(context)
+					.publishOn(Schedulers.boundedElastic())
+					.subscribe(chatWriter::saveChatData);
+			});
 
 		// 4. 초기 이벤트 주입 (Metadata, Warning)
 		return injectInitialEvents(eventFlux, chatId);
@@ -86,163 +85,11 @@ public class ChatService {
 	 * @return 시간순(과거 - > 현재)으로 정렬된 대화 내역 리스트 (User/Assistant 쌍)
 	 */
 	public List<ChatHistoryResponse> getChatHistory(String chatId) {
-		// 1. DB 조회 (최신순 6개)
-		List<ChatMessage> rawHistory = chatMessageRepository.findTop6ByChatIdOrderByCreatedDateDesc(chatId);
-
-		// 2. 변환 (역순 정렬 및 DTO 매핑)
-		return convertToHistoryResponse(rawHistory);
-	}
-
-	/**
-	 * AI 응답 처리 및 SSeEventFactory를 이용한 이벤트 변환
-	 */
-	private ServerSentEvent<String> processAiResponse(AiServiceResponse response, StreamState state) {
-		String type = response.getType();
-
-		if ("delta".equals(type)) {
-			String content = response.getContent();
-			if (content != null) {
-				state.appendAnswer(content);
-			}
-			return sseEventFactory.createDelta(content);
-
-		} else if ("metadata".equals(type)) {
-			Map<String, Object> data = response.getData();
-			state.updateMetadata(data);
-
-			// 클라이언트 전송용 데이터 가공 (chatId 추가)
-			Map<String, Object> eventData = data != null ? new HashMap<>(data) : new HashMap<>();
-			eventData.put("chatId", state.getChatId());
-
-			return sseEventFactory.createMetadata(eventData);
-
-		} else if ("error".equals(type)) {
-			return sseEventFactory.createError(response.getData(), response.getMessage());
-		}
-
-		return sseEventFactory.createKeepAlive();
-	}
-
-	/**
-	 * 스트림 완료 후 누적된 데이터를 DB에 저장 (비동기)
-	 */
-	private void saveChatData(StreamState state) {
-		if (state.getAnswerBuilder().isEmpty()
-			&& (state.getMetadataMap() == null || state.getMetadataMap().isEmpty())
-			&& (state.getTotalTokens() == null || state.getTotalTokens() == 0)) {
-			return;
-		}
-
-		// 1. ChatMessage 저장
-		ChatMessage chatMessage = ChatMessage.builder()
-			.chatId(state.getChatId())
-			.question(state.getQuestion())
-			.answer(state.getAnswer())
-			.decision(state.getDecision())
-			.build();
-
-		// blocking IO를 별도 스레드에서 실행 (Reactor 권장)
-		// 실제 운영 시에는 ReactiveMongoRepository를 쓰거나 subscribeOn 사용
-		Flux.just(chatMessage)
-			.publishOn(Schedulers.boundedElastic())
-			.doOnNext(msg -> {
-				ChatMessage savedMsg = chatMessageRepository.save(msg);
-				String messageId = savedMsg.getId();
-				saveTokenAndMetadata(state, messageId);
-			})
-			.subscribe(
-				success -> {
-				},
-				error -> log.error("채팅 데이터 저장 실패: chatId={}", state.getChatId(), error)
-			);
-	}
-
-	private void saveTokenAndMetadata(StreamState state, String messageId) {
-		// 2. TokenUsage 저장
-		ChatTokenUsage tokenUsage = ChatTokenUsage.builder()
-			.messageId(messageId)
-			.preset(state.getPreset())
-			.totalTokens(state.getTotalTokens())
-			.build();
-		chatTokenUsageRepository.save(tokenUsage);
-
-		// 3. Metadata 저장
-		ChatMetadata metadata = ChatMetadata.builder()
-			.messageId(messageId)
-			.metadata(state.getMetadataMap())
-			.build();
-		chatMetadataRepository.save(metadata);
-	}
-
-	private List<ChatHistoryResponse> convertToHistoryResponse(List<ChatMessage> rawHistory) {
-		// DB에서 최신순으로 가져온 후 시간순(과거->현재)으로 역순 정렬
-		Collections.reverse(rawHistory);
-
-		return rawHistory.stream()
-			.flatMap(msg -> java.util.stream.Stream.of(
-				ChatHistoryResponse.user(msg.getQuestion()),
-				ChatHistoryResponse.assistant(msg.getAnswer())
-			))
-			.toList();
+		return chatReader.getChatHistory(chatId);
 	}
 
 	private Flux<ServerSentEvent<String>> injectInitialEvents(Flux<ServerSentEvent<String>> mainFlux, String chatId) {
 		ServerSentEvent<String> metaEvent = sseEventFactory.createMetadata(Map.of("chatId", chatId));
 		return Flux.just(metaEvent).concatWith(mainFlux);
-	}
-
-	/**
-	 * 스트림 내부 상태 관리용 내부 클래스
-	 */
-	@Getter
-	private static class StreamState {
-		private final String chatId;
-		private final String question;
-		private final StringBuilder answerBuilder = new StringBuilder();
-		private Map<String, Object> metadataMap = new HashMap<>();
-
-		// 추출된 주요 메타데이터
-		private String decision = "";
-		private String preset = "";
-		private Integer totalTokens = 0;
-
-		public StreamState(String chatId, String question) {
-			this.chatId = chatId;
-			this.question = question;
-		}
-
-		public void appendAnswer(String chunk) {
-			this.answerBuilder.append(chunk);
-		}
-
-		public String getAnswer() {
-			return this.answerBuilder.toString();
-		}
-
-		@SuppressWarnings("unchecked")
-		public void updateMetadata(Map<String, Object> data) {
-			if (data == null) {
-				return;
-			}
-			this.metadataMap = data;
-
-			// RAG Decision 추출
-			if (data.get("rag") instanceof Map<?, ?> rag) {
-				Object gateReason = rag.get("gate_reason");
-				this.decision = gateReason != null ? gateReason.toString() : "";
-			}
-
-			// Token Usage 추출
-			if (data.get("token_usage") instanceof Map<?, ?> usage) {
-				Object presetObj = usage.get("preset");
-				this.preset = presetObj != null ? presetObj.toString() : "";
-				Object tokens = usage.get("total_tokens");
-				if (tokens instanceof Number n) {
-					this.totalTokens = n.intValue();
-				} else if (tokens instanceof String s) {
-					this.totalTokens = Integer.parseInt(s);
-				}
-			}
-		}
 	}
 }

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/service/ChatService.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/service/ChatService.java
@@ -32,7 +32,6 @@ import reactor.core.scheduler.Schedulers;
  * 챗봇 서비스 로직
  *
  * <p>
- * Python의 stream_chat_response 로직을 이식<br>
  * 비용 확인 -> 히스토리 조회 -> AI 요청 -> 스트리밍 -> DB 저장
  * </p>
  *
@@ -62,8 +61,7 @@ public class ChatService {
 		usageService.checkLlmUsage();
 
 		// 2. 대화 히스토리 조회
-		List<ChatMessage> rawHistory = chatMessageRepository.findTop6ByChatIdOrderByCreatedDateDesc(chatId);
-		List<ChatHistoryResponse> history = convertToHistoryResponse(rawHistory);
+		List<ChatHistoryResponse> history = getChatHistory(chatId);
 
 		// 스트림 동안 상태(답변, 메타데이터 등)를 누적할 객체 생성
 		StreamState state = new StreamState(chatId, request.getUserInput());
@@ -75,6 +73,25 @@ public class ChatService {
 
 		// 4. 초기 이벤트 주입 (Metadata, Warning)
 		return injectInitialEvents(eventFlux, chatId);
+	}
+
+	/**
+	 * 대화 히스토리 조회
+	 *
+	 * <p>
+	 * 주어진 chatId에 해당하는 최근 대화 내역(최대 6개)을 조회하여 반환<br>
+	 * 컨트롤러의 히스토리 조회 API와 내부 AI 요청 시 대화 문맥 제공용으로 공통 사용
+	 * </p>
+	 *
+	 * @param chatId 사용자 식별 ID (쿠키 값)
+	 * @return 시간순(과거 - > 현재)으로 정렬된 대화 내역 리스트 (User/Assistant 쌍)
+	 */
+	public List<ChatHistoryResponse> getChatHistory(String chatId) {
+		// 1. DB 조회 (최신순 6개)
+		List<ChatMessage> rawHistory = chatMessageRepository.findTop6ByChatIdOrderByCreatedDateDesc(chatId);
+
+		// 2. 변환 (역순 정렬 및 DTO 매핑)
+		return convertToHistoryResponse(rawHistory);
 	}
 
 	/**
@@ -157,8 +174,9 @@ public class ChatService {
 	}
 
 	private List<ChatHistoryResponse> convertToHistoryResponse(List<ChatMessage> rawHistory) {
-		// DB에서 최신순으로 가져온 후 역순 정렬
+		// DB에서 최신순으로 가져온 후 시간순(과거->현재)으로 역순 정렬
 		Collections.reverse(rawHistory);
+
 		return rawHistory.stream()
 			.flatMap(msg -> java.util.stream.Stream.of(
 				ChatHistoryResponse.user(msg.getQuestion()),

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/service/ChatService.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/service/ChatService.java
@@ -13,6 +13,7 @@ import com.hallachatbot.backend.domain.chat.dto.request.ChatRequest;
 import com.hallachatbot.backend.domain.chat.dto.response.ChatHistoryResponse;
 import com.hallachatbot.backend.domain.usage.service.UsageService;
 import com.hallachatbot.backend.global.client.service.AiServiceClient;
+import com.hallachatbot.backend.global.exception.ChatStreamErrorHandler;
 import com.hallachatbot.backend.global.sse.SseEventFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -41,6 +42,7 @@ public class ChatService {
 	private final ChatReader chatReader;
 	private final ChatWriter chatWriter;
 	private final ChatStreamHandler chatStreamHandler;
+	private final ChatStreamErrorHandler chatStreamErrorHandler;
 
 	/**
 	 * 채팅 스트리밍 시작
@@ -62,11 +64,14 @@ public class ChatService {
 		// 3. AI 서비스 호출 및 스트리밍 변환
 		Flux<ServerSentEvent<String>> eventFlux = aiServiceClient.streamChat(request, history)
 			.map(aiResponse -> chatStreamHandler.processAiResponse(aiResponse, context))
+			.onErrorResume(chatStreamErrorHandler::handleStreamError)
 			.doOnComplete(() -> {
 				// 저장 로직 비동기 실행
-				Flux.just(context)
-					.publishOn(Schedulers.boundedElastic())
-					.subscribe(chatWriter::saveChatData);
+				if (context.hasAnswer()) { // 답변이 조금이라도 생성되었을 때만 저장
+					Flux.just(context)
+						.publishOn(Schedulers.boundedElastic())
+						.subscribe(chatWriter::saveChatData);
+				}
 			});
 
 		// 4. 초기 이벤트 주입 (Metadata, Warning)

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/service/ChatStreamContext.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/service/ChatStreamContext.java
@@ -77,7 +77,11 @@ public class ChatStreamContext {
 			if (tokens instanceof Number n) {
 				this.totalTokens = n.intValue();
 			} else if (tokens instanceof String s) {
-				this.totalTokens = Integer.parseInt(s);
+				try {
+					this.totalTokens = Integer.parseInt(s);
+				} catch (NumberFormatException e) {
+					this.totalTokens = 0;
+				}
 			}
 		}
 	}

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/service/ChatStreamContext.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/service/ChatStreamContext.java
@@ -1,0 +1,59 @@
+package com.hallachatbot.backend.domain.chat.service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import lombok.Getter;
+
+@Getter
+public class ChatStreamContext {
+	private final String chatId;
+	private final String question;
+	private final StringBuilder answerBuilder = new StringBuilder();
+	private Map<String, Object> metadataMap = new HashMap<>();
+
+	// 추출된 주요 메타데이터
+	private String decision = "";
+	private String preset = "";
+	private Integer totalTokens = 0;
+
+	public ChatStreamContext(String chatId, String question) {
+		this.chatId = chatId;
+		this.question = question;
+	}
+
+	public void appendAnswer(String chunk) {
+		this.answerBuilder.append(chunk);
+	}
+
+	public String getAnswer() {
+		return this.answerBuilder.toString();
+	}
+
+	@SuppressWarnings("unchecked")
+	public void updateMetadata(Map<String, Object> data) {
+		if (data == null) {
+			return;
+		}
+		this.metadataMap = data;
+
+		// RAG Decision 추출
+		if (data.get("rag") instanceof Map<?, ?> rag) {
+			Object gateReason = rag.get("gate_reason");
+			this.decision = gateReason != null ? gateReason.toString() : "";
+		}
+
+		// Token Usage 추출
+		if (data.get("token_usage") instanceof Map<?, ?> usage) {
+			Object presetObj = usage.get("preset");
+			this.preset = presetObj != null ? presetObj.toString() : "";
+
+			Object tokens = usage.get("total_tokens");
+			if (tokens instanceof Number n) {
+				this.totalTokens = n.intValue();
+			} else if (tokens instanceof String s) {
+				this.totalTokens = Integer.parseInt(s);
+			}
+		}
+	}
+}

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/service/ChatStreamContext.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/service/ChatStreamContext.java
@@ -5,6 +5,22 @@ import java.util.Map;
 
 import lombok.Getter;
 
+/**
+ * <b>채팅 스트림 컨텍스트 (State Object)</b>
+ *
+ * <p>
+ * 단일 채팅 요청이 처리되는 동안(스트리밍 수명주기 내) 유지되는 상태 저장소
+ * </p>
+ *
+ * <ul>
+ * <li><b>데이터 누적:</b> 스트리밍으로 조각조각 들어오는 답변(Chunk)을 하나의 완성된 문자열로 조립</li>
+ * <li><b>메타데이터 파싱:</b> AI 서비스로부터 넘어오는 원본 맵(Map) 데이터에서 RAG 결정 사유, 토큰 사용량 등 핵심 정보를 추출하여 관리.</li>
+ * <li><b>임시 저장소:</b> 스트리밍이 끝난 후 {@link com.hallachatbot.backend.domain.chat.component.ChatWriter}가 DB에 저장할 때 이 객체를 참조
+ * </li>
+ * </ul>
+ * @author pwk0131
+ */
+
 @Getter
 public class ChatStreamContext {
 	private final String chatId;
@@ -34,6 +50,11 @@ public class ChatStreamContext {
 		return this.answerBuilder.length() > 0;
 	}
 
+	/**
+	 * 메타데이터 갱신 및 주요 정보(토큰, RAG 사유) 추출
+	 *
+	 * @param data AI 서비스 응답의 'data' 필드 맵
+	 */
 	@SuppressWarnings("unchecked")
 	public void updateMetadata(Map<String, Object> data) {
 		if (data == null) {

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/service/ChatStreamContext.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/service/ChatStreamContext.java
@@ -30,6 +30,10 @@ public class ChatStreamContext {
 		return this.answerBuilder.toString();
 	}
 
+	public boolean hasAnswer() {
+		return this.answerBuilder.length() > 0;
+	}
+
 	@SuppressWarnings("unchecked")
 	public void updateMetadata(Map<String, Object> data) {
 		if (data == null) {

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/global/annotation/ChatSession.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/global/annotation/ChatSession.java
@@ -1,0 +1,22 @@
+package com.hallachatbot.backend.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Parameter(
+	name = "chatId",
+	description = "사용자 식별 쿠키 (자동 주입)",
+	in = ParameterIn.COOKIE,
+	schema = @Schema(type = "string"),
+	hidden = true // Swagger에서 직접 입력받지 않고 쿠키로 처리됨을 명시하거나 숨김 처리
+)
+public @interface ChatSession {
+}

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/global/annotation/ChatSession.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/global/annotation/ChatSession.java
@@ -9,6 +9,24 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+/**
+ * <b>사용자 채팅 세션(Chat ID) 주입 어노테이션</b>
+ *
+ * <p>
+ * 컨트롤러 메서드의 파라미터에 이 어노테이션을 부착하면,
+ * {@link com.hallachatbot.backend.global.resolver.ChatSessionArgumentResolver}가 동작하여
+ * 쿠키(Cookie)에 저장된 'chatId' 값을 자동으로 파싱해 주입함
+ * </p>
+ *
+ * <ul>
+ * <li><b>자동 생성:</b> 쿠키에 chatId가 없는 경우, Resolver가 새로운 ID(ObjectId)를 생성하여 응답 쿠키로 설정하고 주입</li>
+ * <li><b>Swagger 통합:</b> OpenAPI 문서(Swagger UI)상에서 해당 파라미터가 쿠키 영역에 위치함을 명시하거나, 직접 입력하지 않도록 숨김(hidden) 처리함</li>
+ * </ul>
+ *
+ * @see com.hallachatbot.backend.global.resolver.ChatSessionArgumentResolver
+ * @author pwk0131
+ */
+
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
 @Parameter(
@@ -16,7 +34,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 	description = "사용자 식별 쿠키 (자동 주입)",
 	in = ParameterIn.COOKIE,
 	schema = @Schema(type = "string"),
-	hidden = true // Swagger에서 직접 입력받지 않고 쿠키로 처리됨을 명시하거나 숨김 처리
+	hidden = true
 )
 public @interface ChatSession {
 }

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/global/client/dto/AiChatRequest.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/global/client/dto/AiChatRequest.java
@@ -7,7 +7,17 @@ import com.hallachatbot.backend.domain.chat.dto.request.ChatRequest;
 import com.hallachatbot.backend.domain.chat.dto.response.ChatHistoryResponse;
 
 /**
- * AI 서비스 요청 DTO
+ * <b>AI 서비스 요청 DTO</b>
+ *
+ * <p>
+ * AI 모델 서버(LLM Service)로 전송되는 JSON 요청 본문 구조.
+ * 사용자 질문, 대화 문맥(History), 언어 설정 등을 포함.
+ * </p>
+ *
+ * @param userInput      사용자 입력 질문
+ * @param messageHistory 이전 대화 내역 리스트 (Context 유지용)
+ * @param language       답변 생성 시 사용할 언어 설정
+ * @author pwk0131
  */
 public record AiChatRequest(
 	@JsonProperty("user_input")

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/global/client/dto/AiChatRequest.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/global/client/dto/AiChatRequest.java
@@ -6,21 +6,16 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.hallachatbot.backend.domain.chat.dto.request.ChatRequest;
 import com.hallachatbot.backend.domain.chat.dto.response.ChatHistoryResponse;
 
-import lombok.Builder;
-import lombok.Getter;
-
 /**
  * AI 서비스 요청 DTO
  */
-@Getter
-@Builder
-public class AiChatRequest {
-
+public record AiChatRequest(
 	@JsonProperty("user_input")
-	private String userInput;
+	String userInput,
 
 	@JsonProperty("message_history")
-	private List<ChatHistoryResponse> messageHistory;
+	List<ChatHistoryResponse> messageHistory,
 
-	private ChatRequest.Language language;
+	ChatRequest.Language language
+) {
 }

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/global/client/dto/AiServiceResponse.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/global/client/dto/AiServiceResponse.java
@@ -2,37 +2,14 @@ package com.hallachatbot.backend.global.client.dto;
 
 import java.util.Map;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
-
 /**
  * AI 서비스 스트리밍 응답 DTO
  */
-@Getter
-@NoArgsConstructor
-@ToString
-public class AiServiceResponse {
-
-	/**
-	 * 이벤트 타입 (delta, metadata, error)
-	 */
-	private String type;
-
-	/**
-	 * 채팅 내용 (type="delta" 일 때)
-	 */
-	private String content;
-
-	/**
-	 * 메타데이터 또는 에러 상세 (type="metadata" or "error" 일 때)
-	 */
-	private Map<String, Object> data;
-
-	/**
-	 * 에러 메시지 (type="error" 일 때 간혹 사용됨)
-	 */
-	private String message;
-
-	private String code;
+public record AiServiceResponse(
+	String type,
+	String content,
+	Map<String, Object> data,
+	String message,
+	String code
+) {
 }

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/global/client/dto/AiServiceResponse.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/global/client/dto/AiServiceResponse.java
@@ -3,7 +3,19 @@ package com.hallachatbot.backend.global.client.dto;
 import java.util.Map;
 
 /**
- * AI 서비스 스트리밍 응답 DTO
+ * <b>AI 서비스 응답 DTO</b>
+ *
+ * <p>
+ * AI 모델 서버로부터 수신되는 SSE(Server-Sent Events) 스트림의 데이터 단위.<br>
+ * 스트리밍 특성상 완성된 문장이 아닌 조각(Delta) 또는 메타데이터 형태로 전달됨.
+ * </p>
+ *
+ * @param type    응답 유형 (예: "delta", "metadata", "error")
+ * @param content 답변 텍스트 조각 (type="delta"일 경우 존재)
+ * @param data    추가 메타데이터 또는 에러 상세 정보 (Map 구조)
+ * @param message 에러 메시지 (type="error"일 경우 존재)
+ * @param code    에러 코드
+ * @author pwk0131
  */
 public record AiServiceResponse(
 	String type,

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/global/client/dto/AiServiceResponse.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/global/client/dto/AiServiceResponse.java
@@ -8,7 +8,6 @@ import lombok.ToString;
 
 /**
  * AI 서비스 스트리밍 응답 DTO
- * (NDJSON 라인 하나에 해당)
  */
 @Getter
 @NoArgsConstructor

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/global/client/service/AiServiceClient.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/global/client/service/AiServiceClient.java
@@ -1,0 +1,29 @@
+package com.hallachatbot.backend.global.client.service;
+
+import java.util.List;
+
+import com.hallachatbot.backend.domain.chat.dto.request.ChatRequest;
+import com.hallachatbot.backend.domain.chat.dto.response.ChatHistoryResponse;
+import com.hallachatbot.backend.global.client.dto.AiServiceResponse;
+
+import reactor.core.publisher.Flux;
+
+/**
+ * <b>AI 서비스 연동 클라이언트</b>
+ * <b><p>
+ * SSE(또는 NDJSON) 스트림을 받아 처리함
+ * </p></b>
+ *
+ * @author pwk0131
+ */
+public interface AiServiceClient {
+
+	/**
+	 * AI 챗봇 스트리밍 요청
+	 *
+	 * @param request 사용자 요청 정보
+	 * @param history 대화 히스토리
+	 * @return AI 응답 스트림 (Flux)
+	 */
+	Flux<AiServiceResponse> streamChat(ChatRequest request, List<ChatHistoryResponse> history);
+}

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/global/client/service/AiServiceClient.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/global/client/service/AiServiceClient.java
@@ -11,7 +11,7 @@ import reactor.core.publisher.Flux;
 /**
  * <b>AI 서비스 연동 클라이언트</b>
  * <b><p>
- * SSE(또는 NDJSON) 스트림을 받아 처리함
+ * SSE 스트림을 받아 처리함
  * </p></b>
  *
  * @author pwk0131

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/global/client/service/AiServiceClient.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/global/client/service/AiServiceClient.java
@@ -9,21 +9,28 @@ import com.hallachatbot.backend.global.client.dto.AiServiceResponse;
 import reactor.core.publisher.Flux;
 
 /**
- * <b>AI 서비스 연동 클라이언트</b>
- * <b><p>
- * SSE 스트림을 받아 처리함
- * </p></b>
+ * <b>AI 서비스 연동 클라이언트 인터페이스</b>
+ *
+ * <p>
+ * 외부 AI 모델 서버와의 HTTP 통신을 담당.
+ * WebClient를 사용하여 논블로킹(Non-blocking) 방식의 스트리밍 응답을 처리.
+ * </p>
  *
  * @author pwk0131
  */
 public interface AiServiceClient {
 
 	/**
-	 * AI 챗봇 스트리밍 요청
+	 * <b>AI 답변 스트리밍 요청</b>
 	 *
-	 * @param request 사용자 요청 정보
-	 * @param history 대화 히스토리
-	 * @return AI 응답 스트림 (Flux)
+	 * <p>
+	 * 사용자 질문과 대화 내역을 기반으로 AI 서버에 질의하고,
+	 * 실시간으로 생성되는 답변을 Flux 스트림으로 반환.
+	 * </p>
+	 *
+	 * @param request 사용자 질문 및 설정 정보
+	 * @param history 대화 문맥 유지를 위한 과거 메시지 리스트
+	 * @return AI 응답 객체 스트림 (Flux&lt;AiServiceResponse&gt;)
 	 */
 	Flux<AiServiceResponse> streamChat(ChatRequest request, List<ChatHistoryResponse> history);
 }

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/global/client/service/AiServiceClientImpl.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/global/client/service/AiServiceClientImpl.java
@@ -33,9 +33,9 @@ public class AiServiceClientImpl implements AiServiceClient {
 		String endpoint = aiServiceUrl + "/api/chat";
 
 		AiChatRequest aiBody = AiChatRequest.builder()
-			.userInput(request.getUserInput())
+			.userInput(request.userInput())
 			.messageHistory(history)
-			.language(request.getLanguage())
+			.language(request.language())
 			.build();
 
 		// 성능 측정용 변수 (로그)
@@ -52,11 +52,11 @@ public class AiServiceClientImpl implements AiServiceClient {
 			.timeout(Duration.ofSeconds(120))
 			.doOnNext(response -> {
 				// 첫 번째 토큰("delta") 수신 시 시간 로깅
-				if ("delta".equals(response.getType()) && !firstTokenReceived.get() && response.getContent() != null) {
+				if ("delta".equals(response.type()) && !firstTokenReceived.get() && response.content() != null) {
 					firstTokenReceived.set(true);
 					double durationSeconds = (System.nanoTime() - startTime) / 1_000_000_000.0;
 					log.info("[AI 첫 응답 소요 시간]: {}초 | 첫 토큰: {}", String.format("%.4f", durationSeconds),
-						response.getContent());
+						response.content());
 				}
 			})
 			.doOnComplete(() -> {

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/global/client/service/AiServiceClientImpl.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/global/client/service/AiServiceClientImpl.java
@@ -32,11 +32,11 @@ public class AiServiceClientImpl implements AiServiceClient {
 	public Flux<AiServiceResponse> streamChat(ChatRequest request, List<ChatHistoryResponse> history) {
 		String endpoint = aiServiceUrl + "/api/chat";
 
-		AiChatRequest aiBody = AiChatRequest.builder()
-			.userInput(request.userInput())
-			.messageHistory(history)
-			.language(request.language())
-			.build();
+		AiChatRequest aiBody = new AiChatRequest(
+			request.userInput(),
+			history,
+			request.language()
+		);
 
 		// 성능 측정용 변수 (로그)
 		long startTime = System.nanoTime();

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/global/client/service/AiServiceClientImpl.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/global/client/service/AiServiceClientImpl.java
@@ -19,6 +19,21 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Flux;
 
+/**
+ * <b>AI 서비스 연동 클라이언트 구현체</b>
+ *
+ * <p>
+ * Spring WebClient를 활용하여 외부 AI API와 비동기 통신을 수행.
+ * </p>
+ *
+ * <ul>
+ * <li><b>타임아웃:</b> 120초 (응답 지연 시 연결 종료)</li>
+ * <li><b>모니터링:</b> 첫 토큰 수신 시간(TTFT) 및 전체 응답 시간 로깅</li>
+ * <li><b>에러 처리:</b> HTTP 상태 코드에 따른 예외 로깅</li>
+ * </ul>
+ *
+ * @author pwk0131
+ */
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -29,6 +44,17 @@ public class AiServiceClientImpl implements AiServiceClient {
 	@Value("${app.ai-service-url}")
 	private String aiServiceUrl;
 
+	/**
+	 * {@inheritDoc}
+	 *
+	 * <p>
+	 * <b>동작 과정:</b><br>
+	 * 1. 요청 DTO 생성 및 엔드포인트 설정<br>
+	 * 2. POST 요청 전송 (Content-Type: application/json)<br>
+	 * 3. 응답 본문을 {@link AiServiceResponse} 스트림으로 변환<br>
+	 * 4. 첫 번째 데이터(Delta) 수신 시점과 완료 시점의 소요 시간을 계산하여 로깅
+	 * </p>
+	 */
 	public Flux<AiServiceResponse> streamChat(ChatRequest request, List<ChatHistoryResponse> history) {
 		String endpoint = aiServiceUrl + "/api/chat";
 

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/global/client/service/AiServiceClientImpl.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/global/client/service/AiServiceClientImpl.java
@@ -1,4 +1,4 @@
-package com.hallachatbot.backend.global.client;
+package com.hallachatbot.backend.global.client.service;
 
 import java.time.Duration;
 import java.util.List;
@@ -19,33 +19,16 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Flux;
 
-/**
- * AI 서비스 연동 클라이언트
- *
- * <p>
- * Python의 httpx 로직을 WebClient로 이식<br>
- * SSE(또는 NDJSON) 스트림을 받아 처리함
- * </p>
- *
- * @author pwk0131
- */
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class AiServiceClient {
+public class AiServiceClientImpl implements AiServiceClient {
 
 	private final WebClient.Builder webClientBuilder;
 
 	@Value("${app.ai-service-url}")
 	private String aiServiceUrl;
 
-	/**
-	 * AI 챗봇 스트리밍 요청
-	 *
-	 * @param request 사용자 요청 정보
-	 * @param history 대화 히스토리
-	 * @return AI 응답 스트림 (Flux)
-	 */
 	public Flux<AiServiceResponse> streamChat(ChatRequest request, List<ChatHistoryResponse> history) {
 		String endpoint = aiServiceUrl + "/api/chat";
 

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/global/config/WebConfig.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/global/config/WebConfig.java
@@ -55,11 +55,11 @@ public class WebConfig implements WebMvcConfigurer {
 	 */
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {
-		registry.addMapping("/**") // 모든 경로에 대해
-			.allowedOriginPatterns("http://localhost:3000", "http://localhost:5173") // 허용할 프론트엔드 주소
-			.allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS") // 허용할 HTTP 메서드
-			.allowedHeaders("*") // 모든 헤더 허용
-			.allowCredentials(true) // 쿠키(Session ID) 인증 요청 허용
-			.maxAge(3600); // 전송 요청(Preflight) 캐시 시간
+		registry.addMapping("/**")
+			.allowedOriginPatterns("http://localhost:3000", "http://localhost:5173")
+			.allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+			.allowedHeaders("*")
+			.allowCredentials(true)
+			.maxAge(3600);
 	}
 }

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/global/config/WebConfig.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/global/config/WebConfig.java
@@ -52,7 +52,7 @@ public class WebConfig implements WebMvcConfigurer {
 	 * </p>
 	 *
 	 * <ul>
-	 * <li><b>허용 Origin:</b> 로컬 개발 환경(3000, 5173 포트)</li>
+	 * <li><b>허용 Origin:</b> 배포: 서비스 도메인, 로컬: localhost:5173</li>
 	 * <li><b>허용 Method:</b> GET, POST, OPTIONS</li>
 	 * <li><b>Credentials:</b> 쿠키(Cookie) 기반 인증을 위해 true로 설정</li>
 	 * </ul>

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/global/config/WebConfig.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/global/config/WebConfig.java
@@ -11,17 +11,48 @@ import com.hallachatbot.backend.global.resolver.ChatSessionArgumentResolver;
 
 import lombok.RequiredArgsConstructor;
 
+/**
+ * <b>웹 MVC 전역 설정 (WebConfig)</b>
+ *
+ * <p>
+ * Spring MVC의 동작 방식을 커스터마이징하기 위한 설정 클래스임.
+ * {@link WebMvcConfigurer}를 구현하여 커스텀 파라미터 리졸버를 추가하고,
+ * 프론트엔드와의 통신을 위한 CORS 정책을 정의함.
+ * </p>
+ * @author pwk0131
+ */
 @Configuration
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
 
 	private final ChatSessionArgumentResolver chatSessionArgumentResolver;
 
+	/**
+	 * 커스텀 Argument Resolver 등록
+	 *
+	 * <p>
+	 * {@link com.hallachatbot.backend.global.annotation.ChatSession} 어노테이션 처리를 위한
+	 * {@link ChatSessionArgumentResolver}를 MVC 파이프라인에 추가함.
+	 * </p>
+	 */
 	@Override
 	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
 		resolvers.add(chatSessionArgumentResolver);
 	}
 
+	/**
+	 * CORS (Cross-Origin Resource Sharing) 설정
+	 *
+	 * <p>
+	 * 프론트엔드 애플리케이션(React, Vue 등)과 백엔드 API 간의 자원 공유를 허용하기 위한 정책을 설정함.
+	 * </p>
+	 *
+	 * <ul>
+	 * <li><b>허용 Origin:</b> 로컬 개발 환경(3000, 5173 포트)</li>
+	 * <li><b>허용 Method:</b> GET, POST, PUT, DELETE, OPTIONS</li>
+	 * <li><b>Credentials:</b> 쿠키(Cookie) 기반 인증을 위해 true로 설정</li>
+	 * </ul>
+	 */
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {
 		registry.addMapping("/**") // 모든 경로에 대해

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/global/config/WebConfig.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/global/config/WebConfig.java
@@ -53,7 +53,7 @@ public class WebConfig implements WebMvcConfigurer {
 	 *
 	 * <ul>
 	 * <li><b>허용 Origin:</b> 로컬 개발 환경(3000, 5173 포트)</li>
-	 * <li><b>허용 Method:</b> GET, POST, PUT, DELETE, OPTIONS</li>
+	 * <li><b>허용 Method:</b> GET, POST, OPTIONS</li>
 	 * <li><b>Credentials:</b> 쿠키(Cookie) 기반 인증을 위해 true로 설정</li>
 	 * </ul>
 	 */

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/global/config/WebConfig.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/global/config/WebConfig.java
@@ -1,19 +1,34 @@
 package com.hallachatbot.backend.global.config;
 
+import java.util.List;
+
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import com.hallachatbot.backend.global.resolver.ChatSessionArgumentResolver;
+
+import lombok.RequiredArgsConstructor;
+
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+
+	private final ChatSessionArgumentResolver chatSessionArgumentResolver;
+
+	@Override
+	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+		resolvers.add(chatSessionArgumentResolver);
+	}
 
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {
-		registry.addMapping("/**")                                            // 모든 경로에 대해
-			.allowedOriginPatterns("http://localhost:3000", "http://localhost:5173")        // 허용할 프론트엔드 주소
-			.allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")                    // 허용할 HTTP 메서드
-			.allowedHeaders("*")                                                        // 모든 헤더 허용
-			.allowCredentials(true)                                                        // 쿠키(Session ID) 인증 요청 허용
-			.maxAge(3600);                                                                    // 전송 요청(Preflight) 캐시 시간
+		registry.addMapping("/**") // 모든 경로에 대해
+			.allowedOriginPatterns("http://localhost:3000", "http://localhost:5173") // 허용할 프론트엔드 주소
+			.allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS") // 허용할 HTTP 메서드
+			.allowedHeaders("*") // 모든 헤더 허용
+			.allowCredentials(true) // 쿠키(Session ID) 인증 요청 허용
+			.maxAge(3600); // 전송 요청(Preflight) 캐시 시간
 	}
 }

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/global/config/WebConfig.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/global/config/WebConfig.java
@@ -2,6 +2,7 @@ package com.hallachatbot.backend.global.config;
 
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
@@ -24,6 +25,9 @@ import lombok.RequiredArgsConstructor;
 @Configuration
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+
+	@Value("${app.cors.allowed-origins:http://localhost:5173}")
+	private List<String> allowedOrigins;
 
 	private final ChatSessionArgumentResolver chatSessionArgumentResolver;
 
@@ -56,8 +60,8 @@ public class WebConfig implements WebMvcConfigurer {
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {
 		registry.addMapping("/**")
-			.allowedOriginPatterns("http://localhost:3000", "http://localhost:5173")
-			.allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+			.allowedOriginPatterns(allowedOrigins.toArray(new String[0]))
+			.allowedMethods("GET", "POST", "OPTIONS")
 			.allowedHeaders("*")
 			.allowCredentials(true)
 			.maxAge(3600);

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/global/exception/ChatStreamErrorHandler.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/global/exception/ChatStreamErrorHandler.java
@@ -1,0 +1,80 @@
+package com.hallachatbot.backend.global.exception;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.TimeoutException;
+
+import org.springframework.core.codec.DecodingException;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.hallachatbot.backend.global.errorcode.ChatErrorCode;
+import com.hallachatbot.backend.global.errorcode.ErrorCode;
+import com.hallachatbot.backend.global.sse.SseEventFactory;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Flux;
+
+/**
+ * 채팅 스트리밍 중 발생하는 예외를 처리하는 핸들러.
+ * <p>
+ * GlobalExceptionHandler는 응답 헤더가 전송된 이후(스트리밍 시작 후)의 에러를 잡지 못하므로,
+ * Flux 내부에서 발생하는 에러는 이 핸들러를 통해 SSE 'error' 이벤트로 변환하여 전송함.
+ * </p>
+ * @author pwk0131
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChatStreamErrorHandler {
+
+	private final SseEventFactory sseEventFactory;
+
+	/**
+	 * 예외(Throwable)를 받아 에러 정보를 담은 SSE 이벤트 Flux로 반환
+	 * (onErrorResume 연산자에서 사용)
+	 */
+	public Flux<ServerSentEvent<String>> handleStreamError(Throwable error) {
+		ErrorCode errorCode = determineErrorCode(error);
+
+		// 1. 에러 로그 출력 (서버 모니터링용)
+		log.error("[Stream Error] Cause: {}, Message: {}", error.getClass().getSimpleName(), error.getMessage());
+
+		// 2. 클라이언트에 전달할 에러 데이터 구성
+		Map<String, Object> errorData = Map.of(
+			"code", errorCode.name(),
+			"message", errorCode.getMessage(),
+			"cause", error.getMessage() != null ? error.getMessage() : "Unknown error"
+		);
+
+		// 3. 'error' 타입의 SSE 이벤트 생성 및 반환
+		// 스트림을 끊지 않고 마지막으로 에러 이벤트를 보낸 후 정상 종료(Complete) 처리됨
+		return Flux.just(sseEventFactory.createError(errorData, errorCode.getMessage()));
+	}
+
+	/**
+	 * 예외 타입에 따라 적절한 ErrorCode를 매핑.
+	 */
+	private ErrorCode determineErrorCode(Throwable error) {
+
+		// 1. 타임아웃 (AI 서비스 응답 지연)
+		if (error instanceof TimeoutException) {
+			return ChatErrorCode.AI_SERVICE_UNAVAILABLE;
+		}
+
+		// 2. 데이터 파싱/디코딩 실패 (JSON 형식 오류 등)
+		if (error instanceof DecodingException || error instanceof JsonProcessingException) {
+			return ChatErrorCode.AI_RESPONSE_PARSING_FAILED;
+		}
+
+		// 3. 입출력/네트워크 중단
+		if (error instanceof IOException) {
+			return ChatErrorCode.STREAMING_INTERRUPTED;
+		}
+
+		// 기본값: AI 서비스 내부 오류
+		return ChatErrorCode.AI_SERVICE_ERROR;
+	}
+}

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/global/exception/ChatStreamErrorHandler.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/global/exception/ChatStreamErrorHandler.java
@@ -18,7 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Flux;
 
 /**
- * 채팅 스트리밍 중 발생하는 예외를 처리하는 핸들러.
+ * <b>채팅 스트리밍 중 발생하는 예외를 처리하는 핸들러.</b>
  * <p>
  * GlobalExceptionHandler는 응답 헤더가 전송된 이후(스트리밍 시작 후)의 에러를 잡지 못하므로,
  * Flux 내부에서 발생하는 에러는 이 핸들러를 통해 SSE 'error' 이벤트로 변환하여 전송함.
@@ -39,7 +39,7 @@ public class ChatStreamErrorHandler {
 	public Flux<ServerSentEvent<String>> handleStreamError(Throwable error) {
 		ErrorCode errorCode = determineErrorCode(error);
 
-		// 1. 에러 로그 출력 (서버 모니터링용)
+		// 1. 에러 로그 출력
 		log.error("[Stream Error] Cause: {}, Message: {}", error.getClass().getSimpleName(), error.getMessage());
 
 		// 2. 클라이언트에 전달할 에러 데이터 구성

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/global/exception/ChatStreamErrorHandler.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/global/exception/ChatStreamErrorHandler.java
@@ -45,8 +45,7 @@ public class ChatStreamErrorHandler {
 		// 2. 클라이언트에 전달할 에러 데이터 구성
 		Map<String, Object> errorData = Map.of(
 			"code", errorCode.name(),
-			"message", errorCode.getMessage(),
-			"cause", error.getMessage() != null ? error.getMessage() : "Unknown error"
+			"message", errorCode.getMessage()
 		);
 
 		// 3. 'error' 타입의 SSE 이벤트 생성 및 반환

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/global/exception/GlobalExceptionHandler.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/global/exception/GlobalExceptionHandler.java
@@ -24,7 +24,7 @@ import com.hallachatbot.backend.global.response.Response;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * 전역 예외 처리 핸들러 (Global Exception Handler).
+ * <b>전역 예외 처리 핸들러 (Global Exception Handler).</b>
  * <p>
  * 애플리케이션 전역에서 발생하는 예외를 포착하여 표준화된 {@link Response} 포맷으로 응답합니다.
  * {@link ResponseEntityExceptionHandler}를 상속받아 Spring MVC 표준 예외를 커스터마이징 하여 적용합니다.
@@ -64,10 +64,6 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 	public ResponseEntity<Object> handleAllException(Exception error) {
 		return handleExceptionInternal(GlobalErrorCode.INTERNAL_SERVER_ERROR, error.getMessage());
 	}
-
-	// =================================================================================
-	// Override ResponseEntityExceptionHandler (Spring MVC Standard Exceptions)
-	// =================================================================================
 
 	/**
 	 * [400] @Valid 유효성 검사 실패 처리.
@@ -134,10 +130,6 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 		return handleExceptionInternal(GlobalErrorCode.UNSUPPORTED_MEDIA_TYPE, ex.getMessage());
 	}
 
-	// =================================================================================
-	// Other Common Exceptions
-	// =================================================================================
-
 	/**
 	 * [400] 파라미터 타입 불일치 처리.
 	 */
@@ -156,12 +148,13 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 		return handleExceptionInternal(GlobalErrorCode.MISSING_REQUIRED_HEADER, error.getMessage());
 	}
 
-	// =================================================================================
-	// Common Handler Method (로그 및 응답 통합)
-	// =================================================================================
-
+	/**
+	 * <b>[로깅 로직 중앙화 메서드]</b>
+	 * @param errorCode
+	 * @param logDetail
+	 * @return ResponseEntity
+	 */
 	private ResponseEntity<Object> handleExceptionInternal(ErrorCode errorCode, String logDetail) {
-		// [로깅 로직 중앙화 메서드]
 		// 500번대 에러(Server Error)는 error 레벨로, 400번대(Client Error)는 warn 레벨로 로그 출력
 		if (errorCode.getStatus().is5xxServerError()) {
 			log.error("[Server Error] Code: {}, LogMsg: {}, Detail: {}",

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/global/resolver/ChatSessionArgumentResolver.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/global/resolver/ChatSessionArgumentResolver.java
@@ -19,10 +19,35 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * <b>ChatSession 파라미터 리졸버</b>
+ *
+ * <p>
+ * 컨트롤러 메서드 파라미터 중 {@link ChatSession} 어노테이션이 부착된 대상에 대해
+ * 사용자 세션 ID(chatId)를 추출하거나 생성하여 주입함.
+ * </p>
+ *
+ * <ul>
+ * <li><b>동작 원리:</b> HTTP 요청의 쿠키에서 'chatId' 값을 탐색.</li>
+ * <li><b>신규 세션:</b> 유효한 쿠키가 없을 경우, 새로운 ObjectId를 생성하여 응답 쿠키(Set-Cookie)로 설정 후 반환.</li>
+ * <li><b>적용 대상:</b> {@code @ChatSession} 어노테이션이 붙은 {@code String} 타입 파라미터.</li>
+ * </ul>
+ * @author pwk0131
+ */
 @Slf4j
 @Component
 public class ChatSessionArgumentResolver implements HandlerMethodArgumentResolver {
 
+	/**
+	 * 파라미터 지원 여부 확인
+	 *
+	 * <p>
+	 * {@link ChatSession} 어노테이션이 존재하고, 파라미터 타입이 {@link String}인 경우에만 수행.
+	 * </p>
+	 *
+	 * @param parameter 검사 대상 메서드 파라미터
+	 * @return 지원 여부 (true/false)
+	 */
 	@Override
 	public boolean supportsParameter(MethodParameter parameter) {
 		// @ChatSession 어노테이션이 붙어있고, 타입이 String인 경우에만 동작
@@ -30,6 +55,17 @@ public class ChatSessionArgumentResolver implements HandlerMethodArgumentResolve
 			&& String.class.isAssignableFrom(parameter.getParameterType());
 	}
 
+	/**
+	 * 파라미터 값(chatId) 해석 및 주입
+	 *
+	 * <p>
+	 * 1. 요청 쿠키에서 'chatId' 값 조회.<br>
+	 * 2. 값이 없거나 유효하지 않은 포맷(ObjectId)일 경우 신규 ID 생성.<br>
+	 * 3. 신규 생성 시 응답 헤더에 쿠키 설정 추가.
+	 * </p>
+	 *
+	 * @return 컨트롤러 파라미터에 전달될 세션 ID 문자열
+	 */
 	@Override
 	public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
 		NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
@@ -62,6 +98,16 @@ public class ChatSessionArgumentResolver implements HandlerMethodArgumentResolve
 		return null;
 	}
 
+	/**
+	 * 클라이언트 브라우저에 쿠키 설정 (Set-Cookie)
+	 *
+	 * <ul>
+	 * <li>Max-Age: 1일 (86400초)</li>
+	 * <li>Secure: true (HTTPS 전용)</li>
+	 * <li>HttpOnly: false (JS 접근 허용)</li>
+	 * <li>Path: / (모든 경로)</li>
+	 * </ul>
+	 */
 	private void setCookie(HttpServletResponse response, String chatId) {
 		if (response == null) {
 			return;

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/global/resolver/ChatSessionArgumentResolver.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/global/resolver/ChatSessionArgumentResolver.java
@@ -1,6 +1,8 @@
 package com.hallachatbot.backend.global.resolver;
 
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.Optional;
 
 import org.bson.types.ObjectId;
 import org.springframework.core.MethodParameter;
@@ -86,16 +88,13 @@ public class ChatSessionArgumentResolver implements HandlerMethodArgumentResolve
 	}
 
 	private String resolveChatIdFromCookie(HttpServletRequest request) {
-		Cookie[] cookies = request.getCookies();
-		if (cookies == null) {
-			return null;
-		}
-		for (Cookie cookie : cookies) {
-			if ("chatId".equals(cookie.getName())) {
-				return cookie.getValue();
-			}
-		}
-		return null;
+		return Optional.ofNullable(request.getCookies())
+			.stream()
+			.flatMap(Arrays::stream)
+			.filter(cookie -> "chatId".equals(cookie.getName()))
+			.map(Cookie::getValue)
+			.findFirst()
+			.orElse(null);
 	}
 
 	/**

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/global/resolver/ChatSessionArgumentResolver.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/global/resolver/ChatSessionArgumentResolver.java
@@ -104,7 +104,7 @@ public class ChatSessionArgumentResolver implements HandlerMethodArgumentResolve
 	 * <ul>
 	 * <li>Max-Age: 1일 (86400초)</li>
 	 * <li>Secure: true (HTTPS 전용)</li>
-	 * <li>HttpOnly: false (JS 접근 허용)</li>
+	 * <li>HttpOnly: true (JS 접근 불가)</li>
 	 * <li>Path: / (모든 경로)</li>
 	 * </ul>
 	 */
@@ -114,9 +114,9 @@ public class ChatSessionArgumentResolver implements HandlerMethodArgumentResolve
 		}
 
 		ResponseCookie cookie = ResponseCookie.from("chatId", chatId)
-			.maxAge(Duration.ofSeconds(86400)) // 1일
-			.secure(true)     // HTTPS 적용 시 필수 (로컬 개발 환경에 따라 조정 필요)
-			.httpOnly(false)  // JS 접근 허용 여부
+			.maxAge(Duration.ofSeconds(86400))
+			.secure(true)
+			.httpOnly(true)
 			.path("/")
 			.build();
 

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/global/resolver/ChatSessionArgumentResolver.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/global/resolver/ChatSessionArgumentResolver.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.Optional;
 
 import org.bson.types.ObjectId;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
@@ -39,6 +40,15 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Component
 public class ChatSessionArgumentResolver implements HandlerMethodArgumentResolver {
+
+	@Value("${app.cookie.http-only}")
+	private boolean cookieHttpOnly;
+
+	@Value("${app.cookie.secure}")
+	private boolean cookieSecure;
+
+	@Value("${app.cookie.same-site}")
+	private String cookieSameSite;
 
 	/**
 	 * 파라미터 지원 여부 확인
@@ -114,8 +124,9 @@ public class ChatSessionArgumentResolver implements HandlerMethodArgumentResolve
 
 		ResponseCookie cookie = ResponseCookie.from("chatId", chatId)
 			.maxAge(Duration.ofSeconds(86400))
-			.secure(true)
-			.httpOnly(true)
+			.secure(cookieSecure)
+			.httpOnly(cookieHttpOnly)
+			.sameSite(cookieSameSite)
 			.path("/")
 			.build();
 

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/global/resolver/ChatSessionArgumentResolver.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/global/resolver/ChatSessionArgumentResolver.java
@@ -1,0 +1,79 @@
+package com.hallachatbot.backend.global.resolver;
+
+import java.time.Duration;
+
+import org.bson.types.ObjectId;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import com.hallachatbot.backend.global.annotation.ChatSession;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class ChatSessionArgumentResolver implements HandlerMethodArgumentResolver {
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		// @ChatSession 어노테이션이 붙어있고, 타입이 String인 경우에만 동작
+		return parameter.hasParameterAnnotation(ChatSession.class)
+			&& String.class.isAssignableFrom(parameter.getParameterType());
+	}
+
+	@Override
+	public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+		NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+
+		HttpServletRequest request = (HttpServletRequest)webRequest.getNativeRequest();
+		HttpServletResponse response = (HttpServletResponse)webRequest.getNativeResponse();
+
+		String chatId = resolveChatIdFromCookie(request);
+
+		// 유효한 chatId가 없으면 새로 생성 후 쿠키 발급
+		if (chatId == null || !ObjectId.isValid(chatId)) {
+			chatId = new ObjectId().toHexString();
+			setCookie(response, chatId);
+			log.info("New chat session created: {}", chatId);
+		}
+
+		return chatId;
+	}
+
+	private String resolveChatIdFromCookie(HttpServletRequest request) {
+		Cookie[] cookies = request.getCookies();
+		if (cookies == null) {
+			return null;
+		}
+		for (Cookie cookie : cookies) {
+			if ("chatId".equals(cookie.getName())) {
+				return cookie.getValue();
+			}
+		}
+		return null;
+	}
+
+	private void setCookie(HttpServletResponse response, String chatId) {
+		if (response == null) {
+			return;
+		}
+
+		ResponseCookie cookie = ResponseCookie.from("chatId", chatId)
+			.maxAge(Duration.ofSeconds(86400)) // 1일
+			.secure(true)     // HTTPS 적용 시 필수 (로컬 개발 환경에 따라 조정 필요)
+			.httpOnly(false)  // JS 접근 허용 여부
+			.path("/")
+			.build();
+
+		response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+	}
+}

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/global/response/Response.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/global/response/Response.java
@@ -3,6 +3,26 @@ package com.hallachatbot.backend.global.response;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.hallachatbot.backend.global.errorcode.ErrorCode;
 
+/**
+ * <b>API 공통 응답 포맷</b>
+ *
+ * <p>
+ * 애플리케이션의 모든 REST API 응답을 감싸는 표준 규격 객체.
+ * 성공 여부, 결과 데이터, 혹은 실패 시의 에러 상세 정보를 포함함.
+ * </p>
+ *
+ * <ul>
+ * <li><b>성공 시:</b> isSuccess=true, data={payload}</li>
+ * <li><b>실패 시:</b> isSuccess=false, errorCode={code}, errorMessage={msg}</li>
+ * </ul>
+ * @author pwk0131
+ *
+ * @param isSuccess    요청 처리 성공 여부
+ * @param errorCode    에러 식별 코드 (실패 시에만 포함, 성공 시 null)
+ * @param errorMessage 에러 상세 메시지 (실패 시에만 포함, 성공 시 null)
+ * @param data         응답 데이터 본문 (성공 시 포함, 데이터가 없으면 null)
+ * @param <T>          응답 데이터(payload)의 타입
+ */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record Response<T>(
 	boolean isSuccess,

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/global/sse/SseEventFactory.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/global/sse/SseEventFactory.java
@@ -16,7 +16,7 @@ import lombok.extern.slf4j.Slf4j;
  * SSE(Server-Sent Events) 프로토콜 표준화 및 생성 팩토리
  * <p>
  * 모든 도메인에서 공통으로 사용할 수 있도록
- * 이벤트 포맷(type, data, content)과 JSON 직렬화를 담당합니다.
+ * 이벤트 포맷(type, data, content)과 JSON 직렬화를 담당
  * </p>
  *
  * @author pwk0131

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/global/sse/SseEventFactory.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/global/sse/SseEventFactory.java
@@ -1,0 +1,85 @@
+package com.hallachatbot.backend.global.sse;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * SSE(Server-Sent Events) 프로토콜 표준화 및 생성 팩토리
+ * <p>
+ * 모든 도메인에서 공통으로 사용할 수 있도록
+ * 이벤트 포맷(type, data, content)과 JSON 직렬화를 담당합니다.
+ * </p>
+ *
+ * @author pwk0131
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SseEventFactory {
+
+	private final ObjectMapper objectMapper;
+
+	/**
+	 * 텍스트 조각(Delta) 이벤트 생성
+	 */
+	public ServerSentEvent<String> createDelta(String content) {
+		return createEvent("delta", null, content);
+	}
+
+	/**
+	 * 메타데이터(Metadata) 이벤트 생성
+	 */
+	public ServerSentEvent<String> createMetadata(Map<String, Object> data) {
+		return createEvent("metadata", data, null);
+	}
+
+	/**
+	 * 에러(Error) 이벤트 생성
+	 */
+	public ServerSentEvent<String> createError(Map<String, Object> data, String message) {
+		return createEvent("error", data, message);
+	}
+
+	/**
+	 * 빈 Keep-Alive 이벤트 생성
+	 */
+	public ServerSentEvent<String> createKeepAlive() {
+		return ServerSentEvent.<String>builder()
+			.comment("keep-alive")
+			.build();
+	}
+
+	/**
+	 * 공통 이벤트 빌더 (JSON 직렬화 포함)
+	 */
+	private ServerSentEvent<String> createEvent(String type, Map<String, Object> data, String content) {
+		Map<String, Object> jsonMap = new HashMap<>();
+		jsonMap.put("type", type);
+
+		if (data != null) {
+			jsonMap.put("data", data);
+		}
+		if (content != null) {
+			jsonMap.put("content", content);
+		}
+
+		try {
+			String jsonString = objectMapper.writeValueAsString(jsonMap);
+			return ServerSentEvent.builder(jsonString).build();
+		} catch (JsonProcessingException e) {
+			log.error("SSE JSON 직렬화 실패: type={}", type, e);
+			// 에러 발생 시 빈 이벤트라도 보내서 스트림 끊김 방지 (혹은 에러 이벤트 전송)
+			return ServerSentEvent.builder("{\"type\":\"error\", \"content\":\"Internal Serialization Error\"}")
+				.build();
+		}
+	}
+}

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/global/sse/SseEventFactory.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/global/sse/SseEventFactory.java
@@ -13,11 +13,17 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * SSE(Server-Sent Events) 프로토콜 표준화 및 생성 팩토리
+ * <b>SSE(Server-Sent Events) 이벤트 생성 팩토리</b>
+ *
  * <p>
- * 모든 도메인에서 공통으로 사용할 수 있도록
- * 이벤트 포맷(type, data, content)과 JSON 직렬화를 담당
+ * 애플리케이션 전역에서 사용되는 SSE 이벤트 객체를 표준화된 포맷으로 생성하는 컴포넌트.
+ * 각 도메인(채팅, 알림 등)은 이 팩토리를 통해 규격화된 이벤트(type, data, content)를 발행함.
  * </p>
+ *
+ * <ul>
+ * <li><b>역할:</b> 이벤트 타입별 구조 정의 및 JSON 직렬화 수행</li>
+ * <li><b>포맷:</b> { "type": "...", "data": {...}, "content": "..." }</li>
+ * </ul>
  *
  * @author pwk0131
  */
@@ -29,28 +35,59 @@ public class SseEventFactory {
 	private final ObjectMapper objectMapper;
 
 	/**
-	 * 텍스트 조각(Delta) 이벤트 생성
+	 * <b>텍스트 조각(Delta) 이벤트 생성</b>
+	 *
+	 * <p>
+	 * AI 답변 스트리밍 시, 생성된 문장의 일부 조각을 전송하기 위해 사용.
+	 * </p>
+	 *
+	 * @param content 전송할 텍스트 조각
+	 * @return type="delta"인 SSE 이벤트 객체
 	 */
 	public ServerSentEvent<String> createDelta(String content) {
 		return createEvent("delta", null, content);
 	}
 
 	/**
-	 * 메타데이터(Metadata) 이벤트 생성
+	 * <b>메타데이터(Metadata) 이벤트 생성</b>
+	 *
+	 * <p>
+	 * 토큰 사용량, RAG 검색 결과, 모델 정보 등 부가 정보를 전송하기 위해 사용.
+	 * 주로 스트리밍 시작 직후 또는 종료 시점에 발행됨.
+	 * </p>
+	 *
+	 * @param data 메타데이터 키-값 맵
+	 * @return type="metadata"인 SSE 이벤트 객체
 	 */
 	public ServerSentEvent<String> createMetadata(Map<String, Object> data) {
 		return createEvent("metadata", data, null);
 	}
 
 	/**
-	 * 에러(Error) 이벤트 생성
+	 * <b>에러(Error) 이벤트 생성</b>
+	 *
+	 * <p>
+	 * 스트리밍 도중 발생한 예외 상황을 클라이언트에 알리기 위해 사용.
+	 * HTTP 연결을 즉시 끊지 않고, 에러 정보를 담은 이벤트를 보낸 후 우아하게 종료 처리함.
+	 * </p>
+	 *
+	 * @param data    에러 관련 상세 데이터 (코드 등)
+	 * @param message 사용자에게 보여줄 에러 메시지
+	 * @return type="error"인 SSE 이벤트 객체
 	 */
 	public ServerSentEvent<String> createError(Map<String, Object> data, String message) {
 		return createEvent("error", data, message);
 	}
 
 	/**
-	 * 빈 Keep-Alive 이벤트 생성
+	 * <b>Keep-Alive 이벤트 생성</b>
+	 *
+	 * <p>
+	 * 연결 타임아웃 방지를 위해 주기적으로 전송하는 빈 이벤트(Heartbeat).
+	 * 데이터 필드 없이 주석(Comment) 필드만 포함함.
+	 * </p>
+	 *
+	 * @return comment="keep-alive"인 SSE 이벤트 객체
 	 */
 	public ServerSentEvent<String> createKeepAlive() {
 		return ServerSentEvent.<String>builder()
@@ -59,7 +96,16 @@ public class SseEventFactory {
 	}
 
 	/**
-	 * 공통 이벤트 빌더 (JSON 직렬화 포함)
+	 * <b>공통 이벤트 빌더 (내부 메서드)</b>
+	 *
+	 * <p>
+	 * 입력된 필드들을 조합하여 JSON 문자열로 직렬화하고, 최종적인 {@link ServerSentEvent} 객체를 생성.
+	 * </p>
+	 *
+	 * @param type    이벤트 유형 (delta, metadata, error 등)
+	 * @param data    구조화된 데이터 맵 (Nullable)
+	 * @param content 단순 텍스트 데이터 (Nullable)
+	 * @return JSON 문자열을 포함한 SSE 이벤트
 	 */
 	private ServerSentEvent<String> createEvent(String type, Map<String, Object> data, String content) {
 		Map<String, Object> jsonMap = new HashMap<>();

--- a/chatbot/backend/src/main/resources/application.yml
+++ b/chatbot/backend/src/main/resources/application.yml
@@ -16,7 +16,6 @@ spring:
 
 app:
   ai-service-url: ${AI_SERVICE_URL:http://localhost:3000}
-
   mongodb-suffix: ${MONGODB_SUFFIX:-stg}
 
   openai-admin-key: ${OPENAI_ADMIN_KEY:}
@@ -25,3 +24,13 @@ app:
   monthly-llm-usage-limit: ${MONTHLY_COST_LIMIT:1000.0}
 
   discord-webhook-url: ${DISCORD_WEBHOOK_URL:}
+
+  cookie:
+    http-only: true
+    secure: true
+    same-site: None
+
+  cors:
+    allowed-origins:
+      - "https://halla-chatbot.com"
+      - "https://www.halla-chatbot.com"

--- a/chatbot/backend/src/test/java/com/hallachatbot/backend/domain/chat/component/ChatMapperTest.java
+++ b/chatbot/backend/src/test/java/com/hallachatbot/backend/domain/chat/component/ChatMapperTest.java
@@ -1,0 +1,40 @@
+package com.hallachatbot.backend.domain.chat.component;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.hallachatbot.backend.domain.chat.dto.response.ChatHistoryResponse;
+import com.hallachatbot.backend.domain.chat.entity.ChatMessage;
+
+class ChatMapperTest {
+
+	private final ChatMapper chatMapper = new ChatMapper();
+
+	@Test
+	@DisplayName("ChatMessage 리스트를 ChatHistoryResponse로 변환하며 역순으로 정렬한다")
+	void toHistoryResponse() {
+		// given
+		// 최신순(내림차순)으로 DB에서 조회된 상황 가정
+		ChatMessage msg1 = ChatMessage.builder().question("질문2").answer("답변2").build(); // 최신
+		ChatMessage msg2 = ChatMessage.builder().question("질문1").answer("답변1").build(); // 과거
+
+		List<ChatMessage> rawHistory = List.of(msg1, msg2);
+
+		// when
+		List<ChatHistoryResponse> responses = chatMapper.toHistoryResponse(rawHistory);
+
+		// then
+		// User/Assistant 쌍으로 쪼개지므로 총 4개의 응답이 나와야 함
+		assertThat(responses).hasSize(4);
+
+		// 순서는 과거(질문1) -> 현재(질문2) 순이어야 함
+		assertThat(responses.get(0).getContent()).isEqualTo("질문1");
+		assertThat(responses.get(1).getContent()).isEqualTo("답변1");
+		assertThat(responses.get(2).getContent()).isEqualTo("질문2");
+		assertThat(responses.get(3).getContent()).isEqualTo("답변2");
+	}
+}

--- a/chatbot/backend/src/test/java/com/hallachatbot/backend/domain/chat/component/ChatMapperTest.java
+++ b/chatbot/backend/src/test/java/com/hallachatbot/backend/domain/chat/component/ChatMapperTest.java
@@ -32,9 +32,9 @@ class ChatMapperTest {
 		assertThat(responses).hasSize(4);
 
 		// 순서는 과거(질문1) -> 현재(질문2) 순이어야 함
-		assertThat(responses.get(0).getContent()).isEqualTo("질문1");
-		assertThat(responses.get(1).getContent()).isEqualTo("답변1");
-		assertThat(responses.get(2).getContent()).isEqualTo("질문2");
-		assertThat(responses.get(3).getContent()).isEqualTo("답변2");
+		assertThat(responses.get(0).content()).isEqualTo("질문1");
+		assertThat(responses.get(1).content()).isEqualTo("답변1");
+		assertThat(responses.get(2).content()).isEqualTo("질문2");
+		assertThat(responses.get(3).content()).isEqualTo("답변2");
 	}
 }

--- a/chatbot/backend/src/test/java/com/hallachatbot/backend/domain/chat/component/ChatReaderTest.java
+++ b/chatbot/backend/src/test/java/com/hallachatbot/backend/domain/chat/component/ChatReaderTest.java
@@ -1,0 +1,89 @@
+package com.hallachatbot.backend.domain.chat.component;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.hallachatbot.backend.domain.chat.dto.response.ChatHistoryResponse;
+import com.hallachatbot.backend.domain.chat.entity.ChatMessage;
+import com.hallachatbot.backend.domain.chat.repository.ChatMessageRepository;
+
+@ExtendWith(MockitoExtension.class)
+class ChatReaderTest {
+
+	@InjectMocks
+	private ChatReader chatReader;
+
+	@Mock
+	private ChatMessageRepository chatMessageRepository;
+
+	@Mock
+	private ChatMapper chatMapper;
+
+	@Test
+	@DisplayName("채팅 내역 조회 시 Repository와 Mapper가 정상적으로 호출되어야 한다")
+	void getChatHistory_Success() {
+		// given
+		String chatId = "test-chat-id";
+
+		// 가짜 엔티티 리스트 생성
+		ChatMessage message = ChatMessage.builder()
+			.question("질문")
+			.answer("답변")
+			.chatId(chatId)
+			.build();
+		List<ChatMessage> rawHistory = List.of(message);
+
+		// 가짜 응답 DTO 리스트 생성 (Record 사용)
+		ChatHistoryResponse responseDto = ChatHistoryResponse.user("질문");
+		List<ChatHistoryResponse> convertedHistory = List.of(responseDto);
+
+		// Mocking: Repository가 호출되면 엔티티 리스트 반환
+		given(chatMessageRepository.findTop6ByChatIdOrderByCreatedDateDesc(chatId))
+			.willReturn(rawHistory);
+
+		// Mocking: Mapper가 호출되면 DTO 리스트 반환
+		given(chatMapper.toHistoryResponse(rawHistory))
+			.willReturn(convertedHistory);
+
+		// when
+		List<ChatHistoryResponse> result = chatReader.getChatHistory(chatId);
+
+		// then
+		assertThat(result).hasSize(1);
+		assertThat(result.get(0).content()).isEqualTo("질문");
+
+		// 검증: 순서대로 잘 호출했는지 확인
+		verify(chatMessageRepository).findTop6ByChatIdOrderByCreatedDateDesc(chatId);
+		verify(chatMapper).toHistoryResponse(rawHistory);
+	}
+
+	@Test
+	@DisplayName("채팅 내역이 없으면 빈 리스트를 반환해야 한다")
+	void getChatHistory_Empty() {
+		// given
+		String chatId = "empty-chat-id";
+
+		given(chatMessageRepository.findTop6ByChatIdOrderByCreatedDateDesc(chatId))
+			.willReturn(Collections.emptyList());
+
+		given(chatMapper.toHistoryResponse(Collections.emptyList()))
+			.willReturn(Collections.emptyList());
+
+		// when
+		List<ChatHistoryResponse> result = chatReader.getChatHistory(chatId);
+
+		// then
+		assertThat(result).isEmpty();
+	}
+}

--- a/chatbot/backend/src/test/java/com/hallachatbot/backend/domain/chat/component/ChatStreamHandlerTest.java
+++ b/chatbot/backend/src/test/java/com/hallachatbot/backend/domain/chat/component/ChatStreamHandlerTest.java
@@ -1,0 +1,120 @@
+package com.hallachatbot.backend.domain.chat.component;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.codec.ServerSentEvent;
+
+import com.hallachatbot.backend.domain.chat.service.ChatStreamContext;
+import com.hallachatbot.backend.global.client.dto.AiServiceResponse;
+import com.hallachatbot.backend.global.sse.SseEventFactory;
+
+@ExtendWith(MockitoExtension.class)
+class ChatStreamHandlerTest {
+
+	@InjectMocks
+	private ChatStreamHandler chatStreamHandler;
+
+	@Mock
+	private SseEventFactory sseEventFactory;
+
+	@Test
+	@DisplayName("Delta 타입 응답이 오면 Context에 답변을 누적하고 SSE 이벤트를 생성한다")
+	void processAiResponse_Delta() {
+		// given
+		ChatStreamContext context = new ChatStreamContext("chat-1", "질문");
+		AiServiceResponse response = new AiServiceResponse();
+
+		// Reflection으로 private 필드 설정
+		org.springframework.test.util.ReflectionTestUtils.setField(response, "type", "delta");
+		org.springframework.test.util.ReflectionTestUtils.setField(response, "content", "안녕");
+
+		given(sseEventFactory.createDelta(anyString()))
+			.willReturn(ServerSentEvent.builder("data").build());
+
+		// when
+		chatStreamHandler.processAiResponse(response, context);
+
+		// then
+		assertThat(context.getAnswer()).isEqualTo("안녕");
+	}
+
+	@Test
+	@DisplayName("Metadata 타입 응답이 오면 Context에 메타데이터를 파싱하여 업데이트한다")
+	void processAiResponse_Metadata() {
+		// given
+		ChatStreamContext context = new ChatStreamContext("chat-1", "질문");
+
+		// 복잡한 맵 구조 생성 (Token Usage, RAG Decision)
+		Map<String, Object> usage = Map.of("total_tokens", 100, "preset", "gpt-4");
+		Map<String, Object> rag = Map.of("gate_reason", "search_needed");
+		Map<String, Object> data = Map.of("token_usage", usage, "rag", rag);
+
+		AiServiceResponse response = new AiServiceResponse();
+		org.springframework.test.util.ReflectionTestUtils.setField(response, "type", "metadata");
+		org.springframework.test.util.ReflectionTestUtils.setField(response, "data", data);
+
+		given(sseEventFactory.createMetadata(anyMap()))
+			.willReturn(ServerSentEvent.builder("meta").build());
+
+		// when
+		chatStreamHandler.processAiResponse(response, context);
+
+		// then
+		assertThat(context.getTotalTokens()).isEqualTo(100);
+		assertThat(context.getPreset()).isEqualTo("gpt-4");
+		assertThat(context.getDecision()).isEqualTo("search_needed");
+	}
+
+	@Test
+	@DisplayName("Error 타입 응답이 오면 에러 SSE 이벤트를 반환한다")
+	void processAiResponse_Error() {
+		// given
+		ChatStreamContext context = new ChatStreamContext("chat-1", "질문");
+		AiServiceResponse response = new AiServiceResponse();
+		org.springframework.test.util.ReflectionTestUtils.setField(response, "type", "error");
+		org.springframework.test.util.ReflectionTestUtils.setField(response, "message", "문제가 발생했습니다");
+
+		given(sseEventFactory.createError(any(), anyString()))
+			.willReturn(ServerSentEvent.builder("error-event").build());
+
+		// when
+		chatStreamHandler.processAiResponse(response, context);
+
+		// then
+		// createError가 호출되었는지 검증
+		verify(sseEventFactory).createError(any(), eq("문제가 발생했습니다"));
+	}
+
+	@Test
+	@DisplayName("알 수 없는 타입의 응답이 오면 KeepAlive(Ping) 이벤트를 반환한다")
+	void processAiResponse_UnknownType() {
+		// given
+		ChatStreamContext context = new ChatStreamContext("chat-1", "질문");
+		AiServiceResponse response = new AiServiceResponse();
+		org.springframework.test.util.ReflectionTestUtils.setField(response, "type", "unknown_custom_type");
+
+		given(sseEventFactory.createKeepAlive())
+			.willReturn(ServerSentEvent.builder("ping").build());
+
+		// when
+		ServerSentEvent<String> result = chatStreamHandler.processAiResponse(response, context);
+
+		// then
+		verify(sseEventFactory).createKeepAlive();
+		assertThat(result.data()).isEqualTo("ping");
+	}
+}

--- a/chatbot/backend/src/test/java/com/hallachatbot/backend/domain/chat/component/ChatStreamHandlerTest.java
+++ b/chatbot/backend/src/test/java/com/hallachatbot/backend/domain/chat/component/ChatStreamHandlerTest.java
@@ -36,11 +36,7 @@ class ChatStreamHandlerTest {
 	void processAiResponse_Delta() {
 		// given
 		ChatStreamContext context = new ChatStreamContext("chat-1", "질문");
-		AiServiceResponse response = new AiServiceResponse();
-
-		// Reflection으로 private 필드 설정
-		org.springframework.test.util.ReflectionTestUtils.setField(response, "type", "delta");
-		org.springframework.test.util.ReflectionTestUtils.setField(response, "content", "안녕");
+		AiServiceResponse response = new AiServiceResponse("delta", "안녕", null, null, null);
 
 		given(sseEventFactory.createDelta(anyString()))
 			.willReturn(ServerSentEvent.builder("data").build());
@@ -63,9 +59,7 @@ class ChatStreamHandlerTest {
 		Map<String, Object> rag = Map.of("gate_reason", "search_needed");
 		Map<String, Object> data = Map.of("token_usage", usage, "rag", rag);
 
-		AiServiceResponse response = new AiServiceResponse();
-		org.springframework.test.util.ReflectionTestUtils.setField(response, "type", "metadata");
-		org.springframework.test.util.ReflectionTestUtils.setField(response, "data", data);
+		AiServiceResponse response = new AiServiceResponse("metadata", null, data, null, null);
 
 		given(sseEventFactory.createMetadata(anyMap()))
 			.willReturn(ServerSentEvent.builder("meta").build());
@@ -84,9 +78,7 @@ class ChatStreamHandlerTest {
 	void processAiResponse_Error() {
 		// given
 		ChatStreamContext context = new ChatStreamContext("chat-1", "질문");
-		AiServiceResponse response = new AiServiceResponse();
-		org.springframework.test.util.ReflectionTestUtils.setField(response, "type", "error");
-		org.springframework.test.util.ReflectionTestUtils.setField(response, "message", "문제가 발생했습니다");
+		AiServiceResponse response = new AiServiceResponse("error", null, null, "문제가 발생했습니다", null);
 
 		given(sseEventFactory.createError(any(), anyString()))
 			.willReturn(ServerSentEvent.builder("error-event").build());
@@ -104,8 +96,7 @@ class ChatStreamHandlerTest {
 	void processAiResponse_UnknownType() {
 		// given
 		ChatStreamContext context = new ChatStreamContext("chat-1", "질문");
-		AiServiceResponse response = new AiServiceResponse();
-		org.springframework.test.util.ReflectionTestUtils.setField(response, "type", "unknown_custom_type");
+		AiServiceResponse response = new AiServiceResponse("unknown_custom_type", null, null, null, null);
 
 		given(sseEventFactory.createKeepAlive())
 			.willReturn(ServerSentEvent.builder("ping").build());

--- a/chatbot/backend/src/test/java/com/hallachatbot/backend/domain/chat/component/ChatWriterTest.java
+++ b/chatbot/backend/src/test/java/com/hallachatbot/backend/domain/chat/component/ChatWriterTest.java
@@ -98,26 +98,4 @@ class ChatWriterTest {
 		verify(chatTokenUsageRepository, never()).save(any());
 		verify(chatMetadataRepository, never()).save(any());
 	}
-
-	@Test
-	@DisplayName("데이터 저장 중 예외가 발생하면 로그를 남기고 로직을 종료한다")
-	void saveChatData_ExceptionHandling() {
-		// given
-		ChatStreamContext context = new ChatStreamContext("chat-1", "질문");
-		context.appendAnswer("답변");
-		// 강제로 ID 주입 (테스트 편의상)
-		org.springframework.test.util.ReflectionTestUtils.setField(context, "totalTokens", 100);
-
-		// 첫 번째 저장(ChatMessage) 시 RuntimeException 발생 유도
-		given(chatMessageRepository.save(any())).willThrow(new RuntimeException("DB Connection Error"));
-
-		// when & then
-		// 메서드 실행 시 예외가 발생하지 않아야 함 (내부에서 try-catch로 잡음)
-		org.junit.jupiter.api.Assertions.assertDoesNotThrow(() ->
-			chatWriter.saveChatData(context)
-		);
-
-		// 검증: 예외가 발생했으므로 이후 로직(TokenUsage 저장 등)은 실행되지 않아야 함
-		verify(chatTokenUsageRepository, never()).save(any());
-	}
 }

--- a/chatbot/backend/src/test/java/com/hallachatbot/backend/domain/chat/component/ChatWriterTest.java
+++ b/chatbot/backend/src/test/java/com/hallachatbot/backend/domain/chat/component/ChatWriterTest.java
@@ -1,0 +1,123 @@
+package com.hallachatbot.backend.domain.chat.component;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.hallachatbot.backend.domain.chat.entity.ChatMessage;
+import com.hallachatbot.backend.domain.chat.entity.ChatMetadata;
+import com.hallachatbot.backend.domain.chat.entity.ChatTokenUsage;
+import com.hallachatbot.backend.domain.chat.repository.ChatMessageRepository;
+import com.hallachatbot.backend.domain.chat.repository.ChatMetadataRepository;
+import com.hallachatbot.backend.domain.chat.repository.ChatTokenUsageRepository;
+import com.hallachatbot.backend.domain.chat.service.ChatStreamContext;
+
+@ExtendWith(MockitoExtension.class)
+class ChatWriterTest {
+
+	@InjectMocks
+	private ChatWriter chatWriter;
+
+	@Mock
+	private ChatMessageRepository chatMessageRepository;
+	@Mock
+	private ChatTokenUsageRepository chatTokenUsageRepository;
+	@Mock
+	private ChatMetadataRepository chatMetadataRepository;
+
+	@Test
+	@DisplayName("Context의 내용을 분해하여 Message, Token, Metadata 엔티티로 저장한다")
+	void saveChatData() {
+		// given
+		ChatStreamContext context = new ChatStreamContext("chat-1", "질문");
+		context.appendAnswer("최종 답변");
+		// Context 내부 필드를 강제 설정 (실제로는 Handler가 함)
+		org.springframework.test.util.ReflectionTestUtils.setField(context, "totalTokens", 150);
+		org.springframework.test.util.ReflectionTestUtils.setField(context, "preset", "gpt-4");
+		context.updateMetadata(Map.of("key", "value"));
+
+		// ID 반환 Mocking
+		ChatMessage savedMsg = ChatMessage.builder()
+			.chatId("chat-1")
+			.question("질문")
+			.answer("최종 답변")
+			.build();
+
+		// ReflectionTestUtils로 private id 필드에 값 설정
+		ReflectionTestUtils.setField(savedMsg, "id", "msg-id-123");
+
+		given(chatMessageRepository.save(any(ChatMessage.class))).willReturn(savedMsg);
+
+		// when
+		chatWriter.saveChatData(context);
+
+		// then
+		// 1. ChatMessage 검증
+		ArgumentCaptor<ChatMessage> msgCaptor = ArgumentCaptor.forClass(ChatMessage.class);
+		verify(chatMessageRepository).save(msgCaptor.capture());
+		assertThat(msgCaptor.getValue().getAnswer()).isEqualTo("최종 답변");
+
+		// 2. TokenUsage 검증 (MessageId가 연결되었는지 확인)
+		ArgumentCaptor<ChatTokenUsage> tokenCaptor = ArgumentCaptor.forClass(ChatTokenUsage.class);
+		verify(chatTokenUsageRepository).save(tokenCaptor.capture());
+		assertThat(tokenCaptor.getValue().getMessageId()).isEqualTo("msg-id-123");
+		assertThat(tokenCaptor.getValue().getTotalTokens()).isEqualTo(150);
+
+		// 3. Metadata 검증
+		ArgumentCaptor<ChatMetadata> metaCaptor = ArgumentCaptor.forClass(ChatMetadata.class);
+		verify(chatMetadataRepository).save(metaCaptor.capture());
+		assertThat(metaCaptor.getValue().getMessageId()).isEqualTo("msg-id-123");
+	}
+
+	@Test
+	@DisplayName("답변 내용이 비어있으면 DB에 저장하지 않는다")
+	void saveChatData_EmptyAnswer() {
+		// given
+		// 답변(Answer)을 append 하지 않은 빈 Context
+		ChatStreamContext emptyContext = new ChatStreamContext("chat-1", "질문");
+
+		// when
+		chatWriter.saveChatData(emptyContext);
+
+		// then
+		// 저장소 메서드들이 전혀 호출되지 않았음을 검증 (never())
+		verify(chatMessageRepository, never()).save(any());
+		verify(chatTokenUsageRepository, never()).save(any());
+		verify(chatMetadataRepository, never()).save(any());
+	}
+
+	@Test
+	@DisplayName("데이터 저장 중 예외가 발생하면 로그를 남기고 로직을 종료한다")
+	void saveChatData_ExceptionHandling() {
+		// given
+		ChatStreamContext context = new ChatStreamContext("chat-1", "질문");
+		context.appendAnswer("답변");
+		// 강제로 ID 주입 (테스트 편의상)
+		org.springframework.test.util.ReflectionTestUtils.setField(context, "totalTokens", 100);
+
+		// 첫 번째 저장(ChatMessage) 시 RuntimeException 발생 유도
+		given(chatMessageRepository.save(any())).willThrow(new RuntimeException("DB Connection Error"));
+
+		// when & then
+		// 메서드 실행 시 예외가 발생하지 않아야 함 (내부에서 try-catch로 잡음)
+		org.junit.jupiter.api.Assertions.assertDoesNotThrow(() ->
+			chatWriter.saveChatData(context)
+		);
+
+		// 검증: 예외가 발생했으므로 이후 로직(TokenUsage 저장 등)은 실행되지 않아야 함
+		verify(chatTokenUsageRepository, never()).save(any());
+	}
+}

--- a/chatbot/backend/src/test/java/com/hallachatbot/backend/domain/chat/controller/ChatControllerTest.java
+++ b/chatbot/backend/src/test/java/com/hallachatbot/backend/domain/chat/controller/ChatControllerTest.java
@@ -17,7 +17,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -46,9 +45,7 @@ class ChatControllerTest {
 	@DisplayName("채팅 요청 시 쿠키가 없으면 새 chatId 쿠키를 발급한다")
 	void chat_NoCookie_GeneratesNewCookie() throws Exception {
 		// given
-		ChatRequest request = new ChatRequest();
-		ReflectionTestUtils.setField(request, "userInput", "안녕");
-		ReflectionTestUtils.setField(request, "language", ChatRequest.Language.KOR);
+		ChatRequest request = new ChatRequest("안녕", ChatRequest.Language.KOR);
 
 		given(chatService.startChat(any(ChatRequest.class), any()))
 			.willReturn(Flux.empty());
@@ -66,9 +63,7 @@ class ChatControllerTest {
 	void chat_ValidCookie_MaintainsCookie() throws Exception {
 		// given
 		String existingChatId = new ObjectId().toHexString();
-		ChatRequest request = new ChatRequest();
-		ReflectionTestUtils.setField(request, "userInput", "안녕");
-		ReflectionTestUtils.setField(request, "language", ChatRequest.Language.KOR);
+		ChatRequest request = new ChatRequest("안녕", ChatRequest.Language.KOR);
 
 		given(chatService.startChat(any(ChatRequest.class), eq(existingChatId)))
 			.willReturn(Flux.empty());

--- a/chatbot/backend/src/test/java/com/hallachatbot/backend/domain/chat/controller/ChatControllerTest.java
+++ b/chatbot/backend/src/test/java/com/hallachatbot/backend/domain/chat/controller/ChatControllerTest.java
@@ -88,7 +88,7 @@ class ChatControllerTest {
 		// given
 		String chatId = new ObjectId().toHexString();
 
-		given(chatMessageRepository.findTop6ByChatIdOrderByCreatedDateDesc(chatId))
+		given(chatService.getChatHistory(chatId))
 			.willReturn(Collections.emptyList());
 
 		// when & then

--- a/chatbot/backend/src/test/java/com/hallachatbot/backend/domain/chat/controller/ChatControllerTest.java
+++ b/chatbot/backend/src/test/java/com/hallachatbot/backend/domain/chat/controller/ChatControllerTest.java
@@ -1,7 +1,6 @@
 package com.hallachatbot.backend.domain.chat.controller;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -51,7 +50,7 @@ class ChatControllerTest {
 		ReflectionTestUtils.setField(request, "userInput", "안녕");
 		ReflectionTestUtils.setField(request, "language", ChatRequest.Language.KOR);
 
-		given(chatService.startChat(any(ChatRequest.class), any(), anyBoolean()))
+		given(chatService.startChat(any(ChatRequest.class), any()))
 			.willReturn(Flux.empty());
 
 		// when & then
@@ -71,7 +70,7 @@ class ChatControllerTest {
 		ReflectionTestUtils.setField(request, "userInput", "안녕");
 		ReflectionTestUtils.setField(request, "language", ChatRequest.Language.KOR);
 
-		given(chatService.startChat(any(ChatRequest.class), eq(existingChatId), eq(false)))
+		given(chatService.startChat(any(ChatRequest.class), eq(existingChatId)))
 			.willReturn(Flux.empty());
 
 		// when & then

--- a/chatbot/backend/src/test/java/com/hallachatbot/backend/domain/chat/service/ChatServiceTest.java
+++ b/chatbot/backend/src/test/java/com/hallachatbot/backend/domain/chat/service/ChatServiceTest.java
@@ -4,31 +4,29 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
 import java.util.Collections;
-import java.util.Map;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hallachatbot.backend.domain.chat.component.ChatReader;
+import com.hallachatbot.backend.domain.chat.component.ChatStreamHandler;
+import com.hallachatbot.backend.domain.chat.component.ChatWriter;
 import com.hallachatbot.backend.domain.chat.dto.request.ChatRequest;
-import com.hallachatbot.backend.domain.chat.entity.ChatMessage;
-import com.hallachatbot.backend.domain.chat.repository.ChatMessageRepository;
-import com.hallachatbot.backend.domain.chat.repository.ChatMetadataRepository;
-import com.hallachatbot.backend.domain.chat.repository.ChatTokenUsageRepository;
 import com.hallachatbot.backend.domain.usage.service.UsageService;
 import com.hallachatbot.backend.global.client.dto.AiServiceResponse;
 import com.hallachatbot.backend.global.client.service.AiServiceClient;
@@ -52,16 +50,16 @@ class ChatServiceTest {
 	private AiServiceClient aiServiceClient;
 
 	@Mock
-	private ChatMessageRepository chatMessageRepository;
+	private ChatReader chatReader;
 
 	@Mock
-	private ChatTokenUsageRepository chatTokenUsageRepository;
+	private ChatWriter chatWriter;
 
 	@Mock
-	private ChatMetadataRepository chatMetadataRepository;
+	private ChatStreamHandler chatStreamHandler;
 
-	@Spy
-	private SseEventFactory sseEventFactory = new SseEventFactory(new ObjectMapper());
+	@Mock
+	private SseEventFactory sseEventFactory;
 
 	@Test
 	@DisplayName("비용 한도를 초과하면 채팅을 시작하지 않고 예외가 발생한다")
@@ -95,16 +93,27 @@ class ChatServiceTest {
 		ReflectionTestUtils.setField(request, "language", ChatRequest.Language.KOR);
 
 		// 1. 히스토리 조회 Mock
-		given(chatMessageRepository.findTop6ByChatIdOrderByCreatedDateDesc(chatId))
+		given(chatReader.getChatHistory(chatId))
 			.willReturn(Collections.emptyList());
 
-		// 2. AI 서비스 응답 Mock (Flux)
+		// 2. 초기 Metadata 이벤트 Mock (SseEventFactory)
+		String metadataJson = "{\"type\":\"metadata\",\"chatId\":\"" + chatId + "\"}";
+		given(sseEventFactory.createMetadata(anyMap()))
+			.willReturn(ServerSentEvent.builder(metadataJson).build());
+
+		// 3. AI 응답 및 핸들러 Mock
 		AiServiceResponse deltaResponse = new AiServiceResponse();
 		ReflectionTestUtils.setField(deltaResponse, "type", "delta");
 		ReflectionTestUtils.setField(deltaResponse, "content", "반갑습니다.");
 
+		// 4. AI 클라이언트가 응답을 방출
 		given(aiServiceClient.streamChat(any(ChatRequest.class), anyList()))
 			.willReturn(Flux.just(deltaResponse));
+
+		// 5. ChatStreamHandler가 null이 아닌 SSE 이벤트를 반환하도록 Stubbing 추가
+		String deltaJson = "{\"type\":\"delta\",\"content\":\"반갑습니다.\"}";
+		given(chatStreamHandler.processAiResponse(any(), any()))
+			.willReturn(ServerSentEvent.builder(deltaJson).build());
 
 		// when
 		Flux<ServerSentEvent<String>> resultFlux = chatService.startChat(request, chatId);
@@ -123,8 +132,9 @@ class ChatServiceTest {
 			})
 			.verifyComplete();
 
-		// 검증: 비용 체크가 호출되었는지
-		verify(usageService, times(1)).checkLlmUsage();
+		// 검증
+		verify(usageService).checkLlmUsage();
+		verify(chatWriter, timeout(1000)).saveChatData(any());
 	}
 
 	@Test
@@ -134,61 +144,51 @@ class ChatServiceTest {
 		String chatId = "test-chat-id";
 		ChatRequest request = new ChatRequest();
 		ReflectionTestUtils.setField(request, "userInput", "질문");
-		ReflectionTestUtils.setField(request, "language", ChatRequest.Language.KOR);
 
-		given(chatMessageRepository.findTop6ByChatIdOrderByCreatedDateDesc(chatId))
+		given(chatReader.getChatHistory(chatId))
 			.willReturn(Collections.emptyList());
 
-		given(chatMessageRepository.save(any(ChatMessage.class)))
-			.willAnswer(invocation -> {
-				ChatMessage sourceMsg = invocation.getArgument(0);
+		// 초기 이벤트 Mock
+		given(sseEventFactory.createMetadata(anyMap()))
+			.willReturn(ServerSentEvent.builder("{\"type\":\"metadata\"}").build());
 
-				ChatMessage savedMsg = ChatMessage.builder()
-					.chatId(sourceMsg.getChatId())
-					.question(sourceMsg.getQuestion())
-					.answer(sourceMsg.getAnswer())
-					.decision(sourceMsg.getDecision())
-					.build();
-
-				ReflectionTestUtils.setField(savedMsg, "id", "generated-msg-id");
-
-				return savedMsg;
-			});
-
-		// 다양한 타입의 응답 시뮬레이션
+		// 다양한 타입의 AI 응답 시뮬레이션
 		AiServiceResponse delta = new AiServiceResponse();
 		ReflectionTestUtils.setField(delta, "type", "delta");
-		ReflectionTestUtils.setField(delta, "content", "답변내용");
 
 		AiServiceResponse metadata = new AiServiceResponse();
 		ReflectionTestUtils.setField(metadata, "type", "metadata");
-		// RAG 및 Token 정보가 있는 복잡한 맵 구조
-		Map<String, Object> ragMap = Map.of("gate_reason", "retrieval_needed");
-		Map<String, Object> usageMap = Map.of("preset", "gpt-4", "total_tokens", 150);
-		Map<String, Object> dataMap = new java.util.HashMap<>(); // 가변 Map
-		dataMap.put("rag", ragMap);
-		dataMap.put("token_usage", usageMap);
-		ReflectionTestUtils.setField(metadata, "data", dataMap);
 
 		AiServiceResponse error = new AiServiceResponse();
 		ReflectionTestUtils.setField(error, "type", "error");
-		ReflectionTestUtils.setField(error, "message", "일시적 오류");
 
-		// 순서대로 방출
+		// AI Client Mock
 		given(aiServiceClient.streamChat(any(), anyList()))
 			.willReturn(Flux.just(delta, metadata, error));
+
+		// Handler Mock - 각 응답에 대해 적절한 SSE 반환 설정
+		given(chatStreamHandler.processAiResponse(eq(delta), any()))
+			.willReturn(ServerSentEvent.builder("{\"type\":\"delta\",\"content\":\"답변내용\"}").build());
+
+		given(chatStreamHandler.processAiResponse(eq(metadata), any()))
+			.willReturn(
+				ServerSentEvent.builder("{\"type\":\"metadata\",\"rag\":\"retrieval_needed\",\"preset\":\"gpt-4\"}")
+					.build());
+
+		given(chatStreamHandler.processAiResponse(eq(error), any()))
+			.willReturn(ServerSentEvent.builder("{\"type\":\"error\",\"message\":\"일시적 오류\"}").build());
 
 		// when
 		Flux<ServerSentEvent<String>> resultFlux = chatService.startChat(request, chatId);
 
 		// then
 		StepVerifier.create(resultFlux)
-			.expectNextCount(1) // 초기 metadata(chatId)
+			.expectNextCount(1) // 초기 metadata
 			.assertNext(event -> assertThat(event.data()).contains("delta").contains("답변내용"))
 			.assertNext(event -> {
 				assertThat(event.data()).contains("metadata");
-				assertThat(event.data()).contains("retrieval_needed"); // RAG 정보 확인
-				assertThat(event.data()).contains("gpt-4"); // Token 정보 확인
+				assertThat(event.data()).contains("retrieval_needed");
+				assertThat(event.data()).contains("gpt-4");
 			})
 			.assertNext(event -> {
 				assertThat(event.data()).contains("error");
@@ -196,10 +196,7 @@ class ChatServiceTest {
 			})
 			.verifyComplete();
 
-		// 비동기 저장 로직 검증 (조금 기다렸다가 확인하거나 verify timeout 사용)
-		// 주의: Schedulers.boundedElastic() 때문에 약간의 지연이 있을 수 있음
-		verify(chatMessageRepository, org.mockito.Mockito.timeout(1000).times(1)).save(any(ChatMessage.class));
-		verify(chatTokenUsageRepository, org.mockito.Mockito.timeout(1000).times(1)).save(any());
-		verify(chatMetadataRepository, org.mockito.Mockito.timeout(1000).times(1)).save(any());
+		// ChatWriter(저장 담당)가 호출되었는지 검증
+		verify(chatWriter, timeout(1000).times(1)).saveChatData(any());
 	}
 }

--- a/chatbot/backend/src/test/java/com/hallachatbot/backend/domain/chat/service/ChatServiceTest.java
+++ b/chatbot/backend/src/test/java/com/hallachatbot/backend/domain/chat/service/ChatServiceTest.java
@@ -31,6 +31,7 @@ import com.hallachatbot.backend.domain.usage.service.UsageService;
 import com.hallachatbot.backend.global.client.dto.AiServiceResponse;
 import com.hallachatbot.backend.global.client.service.AiServiceClient;
 import com.hallachatbot.backend.global.errorcode.UsageErrorCode;
+import com.hallachatbot.backend.global.exception.ChatStreamErrorHandler;
 import com.hallachatbot.backend.global.exception.UsageException;
 import com.hallachatbot.backend.global.sse.SseEventFactory;
 
@@ -60,6 +61,9 @@ class ChatServiceTest {
 
 	@Mock
 	private SseEventFactory sseEventFactory;
+
+	@Mock
+	private ChatStreamErrorHandler chatStreamErrorHandler;
 
 	@Test
 	@DisplayName("비용 한도를 초과하면 채팅을 시작하지 않고 예외가 발생한다")
@@ -113,7 +117,17 @@ class ChatServiceTest {
 		// 5. ChatStreamHandler가 null이 아닌 SSE 이벤트를 반환하도록 Stubbing 추가
 		String deltaJson = "{\"type\":\"delta\",\"content\":\"반갑습니다.\"}";
 		given(chatStreamHandler.processAiResponse(any(), any()))
-			.willReturn(ServerSentEvent.builder(deltaJson).build());
+			.willAnswer(invocation -> {
+				AiServiceResponse response = invocation.getArgument(0);
+				ChatStreamContext context = invocation.getArgument(1);
+
+				// Mock이지만 실제 로직처럼 context에 답변을 넣어줘야 hasAnswer()가 true가 됨
+				if ("delta".equals(response.getType())) {
+					context.appendAnswer(response.getContent());
+				}
+
+				return ServerSentEvent.builder(deltaJson).build();
+			});
 
 		// when
 		Flux<ServerSentEvent<String>> resultFlux = chatService.startChat(request, chatId);
@@ -168,7 +182,11 @@ class ChatServiceTest {
 
 		// Handler Mock - 각 응답에 대해 적절한 SSE 반환 설정
 		given(chatStreamHandler.processAiResponse(eq(delta), any()))
-			.willReturn(ServerSentEvent.builder("{\"type\":\"delta\",\"content\":\"답변내용\"}").build());
+			.willAnswer(invocation -> {
+				ChatStreamContext context = invocation.getArgument(1);
+				context.appendAnswer("답변내용"); // Context 업데이트
+				return ServerSentEvent.builder("{\"type\":\"delta\",\"content\":\"답변내용\"}").build();
+			});
 
 		given(chatStreamHandler.processAiResponse(eq(metadata), any()))
 			.willReturn(

--- a/chatbot/backend/src/test/java/com/hallachatbot/backend/domain/chat/service/ChatServiceTest.java
+++ b/chatbot/backend/src/test/java/com/hallachatbot/backend/domain/chat/service/ChatServiceTest.java
@@ -21,7 +21,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.codec.ServerSentEvent;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import com.hallachatbot.backend.domain.chat.component.ChatReader;
 import com.hallachatbot.backend.domain.chat.component.ChatStreamHandler;
@@ -69,7 +68,7 @@ class ChatServiceTest {
 	@DisplayName("비용 한도를 초과하면 채팅을 시작하지 않고 예외가 발생한다")
 	void startChat_Fail_CostExceeded() {
 		// given
-		ChatRequest request = new ChatRequest();
+		ChatRequest request = new ChatRequest("질문", ChatRequest.Language.KOR);
 		String chatId = "test-chat-id";
 
 		// void 메서드에 대한 BDDMockito 예외 발생 설정
@@ -90,11 +89,7 @@ class ChatServiceTest {
 	void startChat_Success() {
 		// given
 		String chatId = "valid-chat-id";
-		String userInput = "안녕하세요";
-		ChatRequest request = new ChatRequest();
-
-		ReflectionTestUtils.setField(request, "userInput", userInput);
-		ReflectionTestUtils.setField(request, "language", ChatRequest.Language.KOR);
+		ChatRequest request = new ChatRequest("안녕하세요", ChatRequest.Language.KOR);
 
 		// 1. 히스토리 조회 Mock
 		given(chatReader.getChatHistory(chatId))
@@ -106,9 +101,7 @@ class ChatServiceTest {
 			.willReturn(ServerSentEvent.builder(metadataJson).build());
 
 		// 3. AI 응답 및 핸들러 Mock
-		AiServiceResponse deltaResponse = new AiServiceResponse();
-		ReflectionTestUtils.setField(deltaResponse, "type", "delta");
-		ReflectionTestUtils.setField(deltaResponse, "content", "반갑습니다.");
+		AiServiceResponse deltaResponse = new AiServiceResponse("delta", "반갑습니다.", null, null, null);
 
 		// 4. AI 클라이언트가 응답을 방출
 		given(aiServiceClient.streamChat(any(ChatRequest.class), anyList()))
@@ -122,8 +115,8 @@ class ChatServiceTest {
 				ChatStreamContext context = invocation.getArgument(1);
 
 				// Mock이지만 실제 로직처럼 context에 답변을 넣어줘야 hasAnswer()가 true가 됨
-				if ("delta".equals(response.getType())) {
-					context.appendAnswer(response.getContent());
+				if ("delta".equals(response.type())) {
+					context.appendAnswer(response.content());
 				}
 
 				return ServerSentEvent.builder(deltaJson).build();
@@ -156,8 +149,7 @@ class ChatServiceTest {
 	void startChat_WithMetadataAndError() {
 		// given
 		String chatId = "test-chat-id";
-		ChatRequest request = new ChatRequest();
-		ReflectionTestUtils.setField(request, "userInput", "질문");
+		ChatRequest request = new ChatRequest("질문", ChatRequest.Language.KOR);
 
 		given(chatReader.getChatHistory(chatId))
 			.willReturn(Collections.emptyList());
@@ -167,14 +159,9 @@ class ChatServiceTest {
 			.willReturn(ServerSentEvent.builder("{\"type\":\"metadata\"}").build());
 
 		// 다양한 타입의 AI 응답 시뮬레이션
-		AiServiceResponse delta = new AiServiceResponse();
-		ReflectionTestUtils.setField(delta, "type", "delta");
-
-		AiServiceResponse metadata = new AiServiceResponse();
-		ReflectionTestUtils.setField(metadata, "type", "metadata");
-
-		AiServiceResponse error = new AiServiceResponse();
-		ReflectionTestUtils.setField(error, "type", "error");
+		AiServiceResponse delta = new AiServiceResponse("delta", null, null, null, null);
+		AiServiceResponse metadata = new AiServiceResponse("metadata", null, null, null, null);
+		AiServiceResponse error = new AiServiceResponse("error", null, null, null, null);
 
 		// AI Client Mock
 		given(aiServiceClient.streamChat(any(), anyList()))

--- a/chatbot/backend/src/test/java/com/hallachatbot/backend/domain/chat/service/ChatServiceTest.java
+++ b/chatbot/backend/src/test/java/com/hallachatbot/backend/domain/chat/service/ChatServiceTest.java
@@ -30,8 +30,8 @@ import com.hallachatbot.backend.domain.chat.repository.ChatMessageRepository;
 import com.hallachatbot.backend.domain.chat.repository.ChatMetadataRepository;
 import com.hallachatbot.backend.domain.chat.repository.ChatTokenUsageRepository;
 import com.hallachatbot.backend.domain.usage.service.UsageService;
-import com.hallachatbot.backend.global.client.AiServiceClient;
 import com.hallachatbot.backend.global.client.dto.AiServiceResponse;
+import com.hallachatbot.backend.global.client.service.AiServiceClient;
 import com.hallachatbot.backend.global.errorcode.UsageErrorCode;
 import com.hallachatbot.backend.global.exception.UsageException;
 

--- a/chatbot/backend/src/test/java/com/hallachatbot/backend/domain/chat/service/ChatServiceTest.java
+++ b/chatbot/backend/src/test/java/com/hallachatbot/backend/domain/chat/service/ChatServiceTest.java
@@ -74,7 +74,7 @@ class ChatServiceTest {
 			.given(usageService).checkLlmUsage();
 
 		// when & then
-		assertThatThrownBy(() -> chatService.startChat(request, chatId, false))
+		assertThatThrownBy(() -> chatService.startChat(request, chatId))
 			.isInstanceOf(UsageException.class)
 			.hasFieldOrPropertyWithValue("errorCode", UsageErrorCode.MONTHLY_LLM_BUDGET_EXCEEDED);
 
@@ -106,7 +106,7 @@ class ChatServiceTest {
 			.willReturn(Flux.just(deltaResponse));
 
 		// when
-		Flux<ServerSentEvent<String>> resultFlux = chatService.startChat(request, chatId, false);
+		Flux<ServerSentEvent<String>> resultFlux = chatService.startChat(request, chatId);
 
 		// then
 		StepVerifier.create(resultFlux)
@@ -124,33 +124,6 @@ class ChatServiceTest {
 
 		// 검증: 비용 체크가 호출되었는지
 		verify(usageService, times(1)).checkLlmUsage();
-	}
-
-	@Test
-	@DisplayName("쿠키가 변조된 경우 경고 메시지 이벤트가 포함된다")
-	void startChat_TamperedCookie() {
-		// given
-		String chatId = "new-chat-id";
-		ChatRequest request = new ChatRequest();
-		ReflectionTestUtils.setField(request, "userInput", "질문");
-
-		given(chatMessageRepository.findTop6ByChatIdOrderByCreatedDateDesc(chatId))
-			.willReturn(Collections.emptyList());
-
-		given(aiServiceClient.streamChat(any(), any()))
-			.willReturn(Flux.empty()); // AI 응답 없음
-
-		// when
-		Flux<ServerSentEvent<String>> resultFlux = chatService.startChat(request, chatId, true);
-
-		// then
-		StepVerifier.create(resultFlux)
-			.expectNextCount(1) // metadata
-			.assertNext(event -> {
-				// 경고 메시지 이벤트 확인
-				assertThat(event.data()).contains("유효하지 않은 쿠키가 감지되어");
-			})
-			.verifyComplete();
 	}
 
 	@Test
@@ -205,7 +178,7 @@ class ChatServiceTest {
 			.willReturn(Flux.just(delta, metadata, error));
 
 		// when
-		Flux<ServerSentEvent<String>> resultFlux = chatService.startChat(request, chatId, false);
+		Flux<ServerSentEvent<String>> resultFlux = chatService.startChat(request, chatId);
 
 		// then
 		StepVerifier.create(resultFlux)

--- a/chatbot/backend/src/test/java/com/hallachatbot/backend/domain/chat/service/ChatServiceTest.java
+++ b/chatbot/backend/src/test/java/com/hallachatbot/backend/domain/chat/service/ChatServiceTest.java
@@ -34,6 +34,7 @@ import com.hallachatbot.backend.global.client.dto.AiServiceResponse;
 import com.hallachatbot.backend.global.client.service.AiServiceClient;
 import com.hallachatbot.backend.global.errorcode.UsageErrorCode;
 import com.hallachatbot.backend.global.exception.UsageException;
+import com.hallachatbot.backend.global.sse.SseEventFactory;
 
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
@@ -60,7 +61,7 @@ class ChatServiceTest {
 	private ChatMetadataRepository chatMetadataRepository;
 
 	@Spy
-	private ObjectMapper objectMapper = new ObjectMapper();
+	private SseEventFactory sseEventFactory = new SseEventFactory(new ObjectMapper());
 
 	@Test
 	@DisplayName("비용 한도를 초과하면 채팅을 시작하지 않고 예외가 발생한다")
@@ -69,7 +70,7 @@ class ChatServiceTest {
 		ChatRequest request = new ChatRequest();
 		String chatId = "test-chat-id";
 
-		// [수정됨] void 메서드에 대한 BDDMockito 예외 발생 설정
+		// void 메서드에 대한 BDDMockito 예외 발생 설정
 		willThrow(new UsageException(UsageErrorCode.MONTHLY_LLM_BUDGET_EXCEEDED))
 			.given(usageService).checkLlmUsage();
 

--- a/chatbot/backend/src/test/java/com/hallachatbot/backend/global/client/service/AiServiceClientTest.java
+++ b/chatbot/backend/src/test/java/com/hallachatbot/backend/global/client/service/AiServiceClientTest.java
@@ -13,6 +13,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hallachatbot.backend.domain.chat.dto.request.ChatRequest;
@@ -87,5 +88,47 @@ class AiServiceClientTest {
 				assertThat(res.getData()).containsEntry("token_usage", java.util.Map.of("total_tokens", 10));
 			})
 			.verifyComplete();
+	}
+
+	@Test
+	@DisplayName("AI 서비스가 4xx/5xx 에러를 반환하면 WebClientResponseException이 전파된다")
+	void streamChat_HttpError() {
+		// given: AI 서버가 400 Bad Request를 반환하도록 설정
+		mockWebServer.enqueue(new MockResponse()
+			.setResponseCode(400)
+			.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+			.setBody("{\"error\": \"Bad Request\"}"));
+
+		ChatRequest request = new ChatRequest();
+		ReflectionTestUtils.setField(request, "userInput", "질문");
+
+		// when
+		Flux<AiServiceResponse> responseFlux = aiServiceClient.streamChat(request, Collections.emptyList());
+
+		// then: 에러가 발생해야 하며, doOnError(WebClientResponseException) 로직이 타게 됨
+		StepVerifier.create(responseFlux)
+			.expectError(WebClientResponseException.class)
+			.verify();
+	}
+
+	@Test
+	@DisplayName("AI 응답이 올바른 JSON 형식이 아니면 파싱 에러가 발생한다")
+	void streamChat_ParsingError() {
+		// given: 유효하지 않은 JSON 본문 반환
+		mockWebServer.enqueue(new MockResponse()
+			.setResponseCode(200)
+			.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+			.setBody("{invalid-json-body...}"));
+
+		ChatRequest request = new ChatRequest();
+		ReflectionTestUtils.setField(request, "userInput", "질문");
+
+		// when
+		Flux<AiServiceResponse> responseFlux = aiServiceClient.streamChat(request, Collections.emptyList());
+
+		// then: JSON 디코딩 실패로 에러 발생 (doOnError의 '그 외 에러' 로직 커버)
+		StepVerifier.create(responseFlux)
+			.expectError()
+			.verify();
 	}
 }

--- a/chatbot/backend/src/test/java/com/hallachatbot/backend/global/client/service/AiServiceClientTest.java
+++ b/chatbot/backend/src/test/java/com/hallachatbot/backend/global/client/service/AiServiceClientTest.java
@@ -54,9 +54,7 @@ class AiServiceClientTest {
 	@DisplayName("AI 서비스가 정상적으로 스트리밍 응답을 반환한다")
 	void streamChat_Success() throws Exception {
 		// given
-		ChatRequest request = new ChatRequest();
-		ReflectionTestUtils.setField(request, "userInput", "질문");
-		ReflectionTestUtils.setField(request, "language", ChatRequest.Language.KOR);
+		ChatRequest request = new ChatRequest("질문", ChatRequest.Language.KOR);
 
 		// Mock Server 응답 설정 (NDJSON 형태 시뮬레이션)
 		String responseBody = """
@@ -76,16 +74,16 @@ class AiServiceClientTest {
 		// then
 		StepVerifier.create(responseFlux)
 			.assertNext(res -> {
-				assertThat(res.getType()).isEqualTo("delta");
-				assertThat(res.getContent()).isEqualTo("안녕");
+				assertThat(res.type()).isEqualTo("delta");
+				assertThat(res.content()).isEqualTo("안녕");
 			})
 			.assertNext(res -> {
-				assertThat(res.getType()).isEqualTo("delta");
-				assertThat(res.getContent()).isEqualTo("하세요");
+				assertThat(res.type()).isEqualTo("delta");
+				assertThat(res.content()).isEqualTo("하세요");
 			})
 			.assertNext(res -> {
-				assertThat(res.getType()).isEqualTo("metadata");
-				assertThat(res.getData()).containsEntry("token_usage", java.util.Map.of("total_tokens", 10));
+				assertThat(res.type()).isEqualTo("metadata");
+				assertThat(res.data()).containsEntry("token_usage", java.util.Map.of("total_tokens", 10));
 			})
 			.verifyComplete();
 	}
@@ -99,8 +97,7 @@ class AiServiceClientTest {
 			.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
 			.setBody("{\"error\": \"Bad Request\"}"));
 
-		ChatRequest request = new ChatRequest();
-		ReflectionTestUtils.setField(request, "userInput", "질문");
+		ChatRequest request = new ChatRequest("질문", ChatRequest.Language.KOR);
 
 		// when
 		Flux<AiServiceResponse> responseFlux = aiServiceClient.streamChat(request, Collections.emptyList());
@@ -120,8 +117,7 @@ class AiServiceClientTest {
 			.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
 			.setBody("{invalid-json-body...}"));
 
-		ChatRequest request = new ChatRequest();
-		ReflectionTestUtils.setField(request, "userInput", "질문");
+		ChatRequest request = new ChatRequest("질문", ChatRequest.Language.KOR);
 
 		// when
 		Flux<AiServiceResponse> responseFlux = aiServiceClient.streamChat(request, Collections.emptyList());

--- a/chatbot/backend/src/test/java/com/hallachatbot/backend/global/client/service/AiServiceClientTest.java
+++ b/chatbot/backend/src/test/java/com/hallachatbot/backend/global/client/service/AiServiceClientTest.java
@@ -1,4 +1,4 @@
-package com.hallachatbot.backend.global.client;
+package com.hallachatbot.backend.global.client.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -34,9 +34,10 @@ class AiServiceClientTest {
 		mockWebServer = new MockWebServer();
 		mockWebServer.start();
 
-		// WebClient는 실제 빌더를 사용
 		WebClient.Builder webClientBuilder = WebClient.builder();
-		aiServiceClient = new AiServiceClient(webClientBuilder);
+
+		aiServiceClient = new AiServiceClientImpl(webClientBuilder);
+
 		objectMapper = new ObjectMapper();
 
 		// 테스트용 Mock Server URL 주입

--- a/chatbot/backend/src/test/java/com/hallachatbot/backend/global/exception/ChatStreamErrorHandlerTest.java
+++ b/chatbot/backend/src/test/java/com/hallachatbot/backend/global/exception/ChatStreamErrorHandlerTest.java
@@ -1,0 +1,91 @@
+package com.hallachatbot.backend.global.exception;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.util.Map;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.codec.ServerSentEvent;
+
+import com.hallachatbot.backend.global.errorcode.ChatErrorCode;
+import com.hallachatbot.backend.global.sse.SseEventFactory;
+
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+@ExtendWith(MockitoExtension.class)
+class ChatStreamErrorHandlerTest {
+
+	@InjectMocks
+	private ChatStreamErrorHandler chatStreamErrorHandler;
+
+	@Mock
+	private SseEventFactory sseEventFactory;
+
+	@Test
+	@DisplayName("TimeoutException이 발생하면 AI_SERVICE_UNAVAILABLE 에러 이벤트로 변환된다")
+	void handleStreamError_Timeout() {
+		// given
+		TimeoutException error = new TimeoutException("Time out occurred");
+
+		ServerSentEvent<String> expectedEvent = ServerSentEvent.<String>builder()
+			.event("error")
+			.data("{\"code\":\"AI_SERVICE_UNAVAILABLE\"}")
+			.build();
+
+		given(sseEventFactory.createError(anyMap(), any()))
+			.willReturn(expectedEvent);
+
+		// when
+		Flux<ServerSentEvent<String>> resultFlux = chatStreamErrorHandler.handleStreamError(error);
+
+		// then
+		StepVerifier.create(resultFlux)
+			.expectNext(expectedEvent)
+			.verifyComplete();
+
+		// Verify: factory가 올바른 에러 코드로 호출되었는지 검증
+		verify(sseEventFactory).createError(
+			argThat(map -> "AI_SERVICE_UNAVAILABLE".equals(map.get("code"))),
+			eq(ChatErrorCode.AI_SERVICE_UNAVAILABLE.getMessage())
+		);
+	}
+
+	@Test
+	@DisplayName("알 수 없는 예외가 발생하면 AI_SERVICE_ERROR 에러 이벤트로 변환된다")
+	void handleStreamError_UnknownException() {
+		// given
+		RuntimeException error = new RuntimeException("Something went wrong");
+
+		ServerSentEvent<String> expectedEvent = ServerSentEvent.<String>builder()
+			.event("error")
+			.data("{\"code\":\"AI_SERVICE_ERROR\"}")
+			.build();
+
+		given(sseEventFactory.createError(anyMap(), any()))
+			.willReturn(expectedEvent);
+
+		// when
+		Flux<ServerSentEvent<String>> resultFlux = chatStreamErrorHandler.handleStreamError(error);
+
+		// then
+		StepVerifier.create(resultFlux)
+			.expectNext(expectedEvent)
+			.verifyComplete();
+	}
+
+	// Mockito ArgumentMatcher를 위한 헬퍼 메서드
+	private Map<String, Object> argThat(java.util.function.Predicate<Map<String, Object>> predicate) {
+		return org.mockito.ArgumentMatchers.argThat(predicate::test);
+	}
+}

--- a/chatbot/backend/src/test/java/com/hallachatbot/backend/global/sse/SseEventFactoryTest.java
+++ b/chatbot/backend/src/test/java/com/hallachatbot/backend/global/sse/SseEventFactoryTest.java
@@ -1,0 +1,81 @@
+package com.hallachatbot.backend.global.sse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.codec.ServerSentEvent;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+class SseEventFactoryTest {
+
+	// 실제 ObjectMapper 사용
+	private final SseEventFactory sseEventFactory = new SseEventFactory(new ObjectMapper());
+
+	@Test
+	@DisplayName("createDelta: JSON 데이터 내부에 type='delta'와 content가 포함된다")
+	void createDelta() {
+		// given
+		String content = "안녕하세요";
+
+		// when
+		ServerSentEvent<String> event = sseEventFactory.createDelta(content);
+
+		// then
+		// 1. SSE 이벤트 이름은 null이어야 함 (구현상 설정하지 않음)
+		assertThat(event.event()).isNull();
+
+		// 2. Data(JSON) 내부에 type과 content가 있어야 함
+		assertThat(event.data()).contains("\"type\":\"delta\"");
+		assertThat(event.data()).contains("\"content\":\"안녕하세요\"");
+	}
+
+	@Test
+	@DisplayName("createMetadata: JSON 데이터 내부에 type='metadata'와 data 객체가 포함된다")
+	void createMetadata() {
+		// given
+		Map<String, Object> data = Map.of("chatId", "123", "tokens", 100);
+
+		// when
+		ServerSentEvent<String> event = sseEventFactory.createMetadata(data);
+
+		// then
+		assertThat(event.event()).isNull();
+		assertThat(event.data()).contains("\"type\":\"metadata\"");
+		assertThat(event.data()).contains("\"chatId\":\"123\"");
+		assertThat(event.data()).contains("\"tokens\":100");
+	}
+
+	@Test
+	@DisplayName("createError: JSON 데이터 내부에 type='error'와 메시지가 포함된다")
+	void createError() {
+		// given
+		Map<String, Object> data = Map.of("code", "500");
+		String message = "Internal Server Error";
+
+		// when
+		ServerSentEvent<String> event = sseEventFactory.createError(data, message);
+
+		// then
+		assertThat(event.event()).isNull();
+		assertThat(event.data()).contains("\"type\":\"error\"");
+		assertThat(event.data()).contains("Internal Server Error");
+		assertThat(event.data()).contains("\"code\":\"500\"");
+	}
+
+	@Test
+	@DisplayName("createKeepAlive: comment 필드에 'keep-alive'가 설정된다")
+	void createKeepAlive() {
+		// when
+		ServerSentEvent<String> event = sseEventFactory.createKeepAlive();
+
+		// then
+		// Keep-Alive는 data나 event가 아니라 comment로 전송됨
+		assertThat(event.event()).isNull();
+		assertThat(event.data()).isNull();
+		assertThat(event.comment()).isEqualTo("keep-alive");
+	}
+}

--- a/chatbot/frontend/js/messages.js
+++ b/chatbot/frontend/js/messages.js
@@ -5,6 +5,7 @@ function getCookie(name) {
     const v = document.cookie.match('(^|;) ?' + name + '=([^;]*)(;|$)');
     return v ? v[2] : null;
 }
+
 // 쿠키 설정하기
 function setCookie(name, value, days) {
     let expires = "";
@@ -15,6 +16,7 @@ function setCookie(name, value, days) {
     }
     document.cookie = name + "=" + (value || "") + expires + "; path=/";
 }
+
 // 쿠키 삭제하기
 function deleteCookie(name) {
     document.cookie = name + '=; expires=Thu, 01 Jan 1970 00:00:01 GMT; path=/;';
@@ -49,15 +51,15 @@ window.addEventListener("DOMContentLoaded", async () => {
     if (storedId) {
         try {
             const res = await fetch(`${window.baseURL}/api/chat/history`, {
-                credentials: 'include' 
+                credentials: 'include'
             });
             if (res.ok) {
                 const history = await res.json();
-                
+
                 if (history && history.length > 0) {
 
                     sendDefaultMessage();
-                    
+
                     history.forEach(msg => {
                         renderMessage(msg.role, msg.content);
                     });
@@ -74,7 +76,6 @@ window.addEventListener("DOMContentLoaded", async () => {
         sendDefaultMessage();
     }
 });
-
 
 
 // 초기 메시지 생성
@@ -96,14 +97,14 @@ const sendDefaultMessage = () => {
 // user-input placeholder 처리
 const setUserInputPlaceHolder = () => {
     const input = document.getElementById("user-input");
-    if(input) input.placeholder = userInputPlaceHolderDict[language];
+    if (input) input.placeholder = userInputPlaceHolderDict[language];
 }
 
 
 // input, send etc...
 const setInputAndSend = () => {
     const userInput = document.getElementById("user-input");
-    const sendBtn = document.getElementById("send-btn"); 
+    const sendBtn = document.getElementById("send-btn");
 
     if (!userInput || !sendBtn) return;
 
@@ -141,7 +142,6 @@ const setInputAndSend = () => {
 }
 
 
-
 // 유저 메시지 추가
 const appendUserMessage = (userMsg) => {
     // 입력창 초기화
@@ -172,7 +172,7 @@ const sendMessage = async () => {
     }
 
     sendBtn.disabled = true;
-    if(langBtn) langBtn.disabled = true;
+    if (langBtn) langBtn.disabled = true;
     isBotResponding = true;
     appendUserMessage(userMsg);
 
@@ -180,7 +180,7 @@ const sendMessage = async () => {
     await appendBotMessage(userMsg);
 
     sendBtn.disabled = false;
-    if(langBtn) langBtn.disabled = false;
+    if (langBtn) langBtn.disabled = false;
     isBotResponding = false;
 }
 
@@ -194,9 +194,9 @@ const appendBotMessage = async (userMsg) => {
         // request
         const resp = await fetch(`${window.baseURL}/api/chat`, {
             method: "POST",
-            headers: { "Content-Type": "application/json" },
+            headers: {"Content-Type": "application/json"},
             credentials: 'include',
-            body: JSON.stringify({ "user_input": userMsg, "language": language })
+            body: JSON.stringify({"user_input": userMsg, "language": language})
         });
 
         // response
@@ -206,23 +206,32 @@ const appendBotMessage = async (userMsg) => {
         let buffer = "";
 
         while (true) {
-            const { done, value } = await reader.read();
+            const {done, value} = await reader.read();
             clearInterval(waitMessageInterval);
 
             if (done) {
                 break;
             }
 
-            buffer += decoder.decode(value, { stream: true });
+            buffer += decoder.decode(value, {stream: true});
 
             const lines = buffer.split("\n");
             buffer = lines.pop();
 
             for (const line of lines) {
-                if (!line.trim()) continue;
+                const trimmedLine = line.trim();
+                if (!trimmedLine) continue;
+
+                if (trimmedLine.startsWith(":")) continue;
+
+                // 'data:' 접두어가 있으면 제거
+                let jsonStr = trimmedLine;
+                if (trimmedLine.startsWith("data:")) {
+                    jsonStr = trimmedLine.replace("data:", "").trim();
+                }
 
                 try {
-                    const json = JSON.parse(line);
+                    const json = JSON.parse(jsonStr);
 
                     // A. 답변 텍스트 (타이핑 효과)
                     if (json.type === "delta") {
@@ -233,34 +242,33 @@ const appendBotMessage = async (userMsg) => {
                             messages.scrollTop = messages.scrollHeight;
                             await new Promise(r => setTimeout(r, 10)); // 10ms 딜레이
                         }
-                    } 
+                    }
                     // B. 에러 메시지
                     else if (json.type === "error") {
                         botMsgElement.innerHTML += `<br><span class="error-msg" style="color:red;">⚠️ ${json.message}</span>`;
                     }
                     // C. 메타데이터 (ID 저장)
                     else if (json.type === "metadata") {
-                        
+
                         if (json.data && json.data.chatId) {
                             setCookie("chatId", json.data.chatId, 1);
-                            
+
                         }
                     }
                 } catch (e) {
                     console.error("Stream parse error:", e);
                 }
-            }   
+            }
 
-            
+
         }
 
-        
-    }
-    catch (error) {
+
+    } catch (error) {
         clearInterval(waitMessageInterval);
         botMsgElement.innerHTML = `❌ ${errorMsgDict[language]}:` + error.message;
     }
-    
+
     messages.scrollTop = messages.scrollHeight;
 };
 
@@ -303,7 +311,7 @@ const initWaitMessageInterval = (botMsgElement) => {
 // 설문조사 메시지 추가
 const appendSurveyMessage = (surveyMsg) => {
     let msgElement = document.createElement("div");
-    
+
     msgElement.innerHTML = `
     <div class="bot-message-container animate">
         <img class="bot-avatar" src="assets/bot-avatar.png" alt="bot" />


### PR DESCRIPTION
## 📌 Summary
<!-- 이 PR이 무엇을 하는지 한 줄로 요약 -->
- chat 도메인 코드를 전반적으로 리팩토링 및 기능을 추가 하였습니다.
---
## 🎯 Background
<!-- 왜 이 변경이 필요한지 (이슈, 요구사항, 맥락) -->
### **리팩토링**
- 컨트롤러(ChatController.java)와 서비스(ChatService.java)에 중복되는 역할 존재, 혹은 많은 책임이 존재하여 분리 필요
- `chatId` 관련된 무의미한 기능들 경량화 (ex: 쿠키 변조 경고 메세지)
- `AiServiceClient`의 사용을 `chat` 도메인에 한정하지 않고 추후 다른 도메인에서 사용할 가능성이 있다 판단하여 글로벌에 인터페이로 변경 필요
- SSE(Server-Sent Events) 사용을 `chat`도메인에 한정하지 않고 확 장성을 위해 `global` 폴더로 이동 및 역할 분리
### **기능추가**
- `GlobalExceptionHandler` 뿐만 아니라 채팅 도중에 발생하는 오류에 대한 예외를 처리하기 위한 기능 추가
### **버그 픽스**
- 로컬 테스트 환경에서 응답 생성 중입니다. 무한 로딩 현상 발견으로 버그 픽스
---

## 🔨 Changes
<!-- 주요 변경 사항을 구체적으로 -->
> 커밋 내역 순서대로 진행합니다.
###  **안쓰이는 chatId 제거**
- `chat`도메인의 request dto 에서 바디에 담길  `chatId`  를 삭제했습니다. 사용하지 않을 가능성이 높기 때문
###  **쿠키 변조 경고 메세지 삭제**
- `chatId`와 관련된 무의미한 기능을 제거했습니다. 추후 다른 기능으로 개발 가능성도 있습니다.
### **히스토리 메서드 중복에 대한 리팩토링**
- `ChatController`에 존재하는 히스토리 기능(대화 목록 가져오기) 을 `ChatService`로 통합했습니다.
### **AI클라이언트 자체를 글로벌에 인터페이스로 변경**
- SSE 스트림을 받아 처리하는 `AiServiceClient`를 인터페이스로 변경하고 `global`폴더로 옮겼습니다.
### **`ChatSessionArgumentResolver` 도입을 통한 컨트롤러 쿠키 관리 로직 분리**
- ChatController 내 혼재되어 있던 쿠키 검증, 생성 및 ResponseCookie 설정 로직을 제거하여 비즈니스 로직에 집중하도록 개선하였습니다.(역할 분리의 일환)
   -  커스텀 어노테이션 `@ChatSession` 및 `ChatSessionArgumentResolver` 구현
   - WebConfig에 ChatSessionArgumentResolver를 등록하여 스프링 MVC 파이프라인에 적용
### **SSE 이벤트 생성 로직 Global 영역으로 분리 및 구조 개선**
- 기존 `ChatService` 내에 비즈니스 로직과 SSE 이벤트 생성(JSON 직렬화, 포맷팅) 코드가 혼재되어 있어, 서비스 계층의 책임이 과도했으므로, Global 영역에 `SseEventFactory` 신규로 추가하여 역할을 분리 하였습니다.
### **`ChatService` 역할 분리 및 컴포넌트화를 통한 구조 개선**
- 비즈니스 로직이 집중된 `ChatService`의 책임을 세부 컴포넌트로 분리하였습니다.
   - `ChatReader`: 채팅 히스토리 조회 및 데이터 읽기 전담 컴포넌트 생성
   - `ChatWriter`: 채팅 메시지, 메타데이터, 토큰 사용량 저장 로직을 캡슐화한 컴포넌트 생성
   - `ChatStreamHandler`: AI 응답 파싱 및 SSE(Server-Sent-Events) 변환 로직 분리
   - `ChatMapper`: Entity와 DTO 간의 변환 로직 분리
   - `ChatStreamContext`: 스트리밍 중 상태 관리를 위한 컨텍스트 객체 추가
### **채팅 스트리밍 중 예외 발생 시 SSE 에러 이벤트 전송 로직 구현**
- `global/exception` 폴더에 ` ChatStreamErrorHandle`를 추가하여 `GlobalExceptionHandler` 가 잡지 못하는 Flux 스트림 내부 예외를 핸들링 할 수 있도록 기능을 추가하였습니다.
- 발생한 예외를 분석하여 클라이언트가 처리 가능한 SSE 'error' 이벤트로 변환 가능합니다.
### **환경 분리 설정**
- 리팩토링을 하면서 CORS, 쿠키 설정에 대한 기능도 추가하였기에 환경분리까지 추가로 진행했습니다.
### **버그픽스: SSE 응답 파싱 에러 및 무한 로딩 문제 수정**
- 변경 구간 -> frontend
- 백엔드 표준 SSE 포맷(`data: {...}`) 수신 시 JSON 파싱 에러가 발생하는 문제가 발생하여 오류를 고쳤습니다.
   - **원인**: 백엔드에서 보내는 데이터 형식(SSE)과 프론트엔드에서 이를 파싱하는 방식의 불일치
   - **해결**: 스트리밍 데이터에서 `data:` 접두어를 제거하고 순수 JSON만 추출하도록 파싱 로직 변경
---
## 🧪 Test & Verification
<!-- 어떻게 검증했는지 -->
- [x] 로컬 테스트 완료
- [x] QA 시나리오 확인
- [x] 기존 기능 영향도 확인
---

## ⚠️ Impact & Risk
<!-- 배포 시 영향 / 주의사항 / 롤백 포인트 -->
- 영향 범위: Webconfig 코드 수정으로 인해, `application-secret.yml` 파일이 필요합니다 @pwk0131 에게 개인 연락 하세요
- 리스크: 로컬 테스트시 리스크 존재
- 롤백 방법: commit 코드 내역으로 롤백 가능

---

## 📝 Notes
<!-- 리뷰어가 알면 좋은 추가 정보 -->
### **기능 회의**
- 추후 회의를 통해 고민 해봐야 할 기능이 몇 개 있다고 판단하여 기존에 존재하는 계획에서 두 가지를 제외했습니다.
  1. 최근 대화목록 6개 가져오기 → 모든 대화 내용 가져오기
  2. DB 저장 과정 보강
### **로컬 테스트**
- `application.yml` 파일이 인텔리제이 빌드 환경으로 되어있어서 도커환경으로만 빌드하시는 분들은 `README.md` 방법으로 런 하시면 안 될 확률이 높습니다.
   - 해결방법_1:  `docker run -d -p 8080:8000 --network chatbot-network --name chatbot-backend-container --env AI_SERVICE_URL=http://chatbot-ai-container:8000 chatbot-backend:latest` 명령어로 환경 변수를 덮어 씌우세요.
   - 해결방법_2: `application.yml` 파일의 `ai-service-url` 변수 기본값을 `${AI_SERVICE_URL:http://chatbot-ai-container:8000}` 로 바꾸세요.
### AI클라이언트 Impl 주석
- 인터페이스(`AiServiceClient`)에만 주석을 작성해 코드 가독성을 유지하려 했으나, 추후 기능을 확장하거나 유지보수할 동아리원들을 위해 구현체(`AiServiceClientImpl`)에도 설명 주석을 추가했습니다. 불필요하다고 판단될 경우, 추후 제거해도 무방합니다.
---

## 🔗 Related Issues
<!-- 관련 이슈 -->
- Closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 쿠키 기반 채팅 세션 자동 주입과 간편한 대화 기록 조회 흐름 도입
  * 표준화된 SSE 이벤트(델타·메타데이터·오류·하트비트) 생성 및 스트리밍 처리 흐름 추가
  * 스트리밍 완료 시 비동기적 대화·토큰·메타데이터 저장 지원

* **버그 수정**
  * 스트리밍 예외를 일관된 SSE 오류 이벤트로 전달
  * 쿠키 및 CORS 설정 정리로 클라이언트 호환성 개선

* **테스트**
  * 세션 해석, SSE 흐름, 저장 로직 등 단위 테스트 추가/보강

* **문서**
  * DTO·응답·설정 관련 Javadoc·설정 문서 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->