### PR TITLE
OpenAI 비용 기반 LLM 사용량 동기화 기능 구현

### DIFF
--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/BackendApplication.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/BackendApplication.java
@@ -3,8 +3,10 @@ package com.hallachatbot.backend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableAsync
+@EnableScheduling
 @SpringBootApplication
 public class BackendApplication {
 

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/usage/client/OpenAiUsageClient.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/usage/client/OpenAiUsageClient.java
@@ -1,0 +1,145 @@
+package com.hallachatbot.backend.domain.usage.client;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Instant;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.hallachatbot.backend.global.errorcode.UsageErrorCode;
+import com.hallachatbot.backend.global.exception.UsageException;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * <b>OpenAI 공식 비용 추적 API 클라이언트</b>
+ *
+ * <p>
+ * OpenAI 관리자 권한을 이용하여 조직단위의 과금 데이터를 조회.
+ * </p>
+ *
+ * @see <a href="https://developers.openai.com/api/reference/resources/organization/subresources/audit_logs/methods/get_costs">OpenAI API Reference - Costs</a>
+ */
+@Slf4j
+@Component
+public class OpenAiUsageClient {
+
+	private final String openAiAdminKey;
+	private final String costsApiUrl;
+	private final RestTemplate restTemplate;
+
+	public OpenAiUsageClient(
+		RestTemplateBuilder restTemplateBuilder,
+		@Value("${app.openai-admin-key}") String openAiAdminKey,
+		@Value("${app.costs-api-url}") String costsApiUrl) {
+		this.restTemplate = restTemplateBuilder.build();
+		this.openAiAdminKey = openAiAdminKey;
+		this.costsApiUrl = costsApiUrl;
+	}
+
+	/**
+	 * <b>이번 달 누적 사용 비용 조회</b>
+	 *
+	 * @return 당월 총 과금액 (USD)
+	 * @throws UsageException OpenAI API 상태 코드에 따른 커스텀 예외
+	 */
+	public BigDecimal fetchMonthlyTotalUsageAmount() {
+		try {
+			// 날짜 계산 (KST 기준 당월 1일 ~ 현재)
+			long[] timeRange = calculateMonthlyTimeRange();
+
+			// URL 및 인증 헤더 조립
+			String requestUrl = buildRequestUrl(timeRange[0], timeRange[1]);
+			HttpEntity<Void> requestEntity = createAuthHeader();
+
+			// API 호출
+			ResponseEntity<JsonNode> response = restTemplate.exchange(
+				requestUrl,
+				HttpMethod.GET,
+				requestEntity,
+				JsonNode.class
+			);
+
+			// 데이터 파싱 및 합산
+			BigDecimal totalCost = parseTotalCost(response.getBody());
+
+			log.info("[OpenAiClient] 당월 누적 비용 조회 (StartTime: {}, EndTime: {}) - 완료 (Total: ${})",
+				timeRange[0], timeRange[1], totalCost);
+
+			return totalCost;
+
+		} catch (HttpClientErrorException e) {
+			log.warn("[OpenAiClient] API 요청 실패 (Status: {}, ErrorBody: {})",
+				e.getStatusCode(), e.getResponseBodyAsString());
+			throw new UsageException(UsageErrorCode.OPENAI_COST_FETCH_FAILED);
+
+		} catch (Exception e) {
+			log.error("[OpenAiClient] 서버 통신 장애 (Message: {})", e.getMessage());
+			throw new UsageException(UsageErrorCode.OPENAI_COST_FETCH_FAILED);
+		}
+	}
+
+	/**
+	 * 한국 시간 기준 당월 1일 00시부터 현재까지의 Unix Timestamp 계산
+	 */
+	private long[] calculateMonthlyTimeRange() {
+		ZoneId seoulZone = ZoneId.of("Asia/Seoul");
+		ZonedDateTime startOfMonth = YearMonth.now(seoulZone).atDay(1).atStartOfDay(seoulZone);
+		return new long[]{startOfMonth.toEpochSecond(), Instant.now().getEpochSecond()};
+	}
+
+	/**
+	 * 조회 기간을 포함한 API 요청 URL 조립
+	 */
+	private String buildRequestUrl(long startTime, long endTime) {
+		return UriComponentsBuilder.fromUriString(costsApiUrl)
+			.queryParam("start_time", startTime)
+			.queryParam("end_time", endTime)
+			.queryParam("limit", 31)
+			.toUriString();
+	}
+
+	/**
+	 * Admin API Key가 포함된 HTTP 인증 헤더 생성
+	 */
+	private HttpEntity<Void> createAuthHeader() {
+		HttpHeaders headers = new HttpHeaders();
+		headers.setBearerAuth(openAiAdminKey);
+		return new HttpEntity<>(headers);
+	}
+
+	/**
+	 * 응답 JSON 노드를 순회하며 달러(USD) 기준 총 사용 금액 합산
+	 */
+	private BigDecimal parseTotalCost(JsonNode rootNode) {
+		BigDecimal totalUsageUsd = BigDecimal.ZERO;
+
+		if (rootNode == null || !rootNode.has("data")) {
+			return totalUsageUsd;
+		}
+
+		for (JsonNode bucket : rootNode.path("data")) {
+			for (JsonNode result : bucket.path("results")) {
+				JsonNode valueNode = result.path("amount").path("value");
+				if (!valueNode.isMissingNode()) {
+					totalUsageUsd = totalUsageUsd.add(new BigDecimal(valueNode.asText()));
+				}
+			}
+		}
+
+		return totalUsageUsd.setScale(6, RoundingMode.HALF_UP);
+	}
+}

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/usage/client/OpenAiUsageClient.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/usage/client/OpenAiUsageClient.java
@@ -43,8 +43,8 @@ public class OpenAiUsageClient {
 
 	public OpenAiUsageClient(
 		RestTemplateBuilder restTemplateBuilder,
-		@Value("${app.openai-admin-key}") String openAiAdminKey,
-		@Value("${app.costs-api-url}") String costsApiUrl) {
+		@Value("${app.openai-admin-key:}") String openAiAdminKey,
+		@Value("${app.costs-api-url:}") String costsApiUrl) {
 		this.restTemplate = restTemplateBuilder.build();
 		this.openAiAdminKey = openAiAdminKey;
 		this.costsApiUrl = costsApiUrl;

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/usage/scheduler/UsageSyncScheduler.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/usage/scheduler/UsageSyncScheduler.java
@@ -1,0 +1,56 @@
+package com.hallachatbot.backend.domain.usage.scheduler;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.YearMonth;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.hallachatbot.backend.domain.usage.client.OpenAiUsageClient;
+import com.hallachatbot.backend.domain.usage.dao.LlmUsageRedisDao;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * <b>OpenAI 누적 사용량 자동 동기화 스케줄러</b>
+ *
+ * <p>
+ * 서버 내부에서 자체적으로 계산한 LLM 사용 추정치와 실제 OpenAI 플랫폼의 청구 비용 간의 차를 보정하기 위해 매일 00시에 배치 작업을 수행.
+ * </p>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UsageSyncScheduler {
+
+	private final LlmUsageRedisDao llmUsageRedisDao;
+	private final OpenAiUsageClient openAiUsageClient;
+
+	/**
+	 * 매일 자정 OpenAI 서버에서 당월 정확한 누적 비용을 조회하여 Redis 캐시 데이터를 갱신
+	 */
+	@Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+	public void syncMonthlyLlmUsage() {
+		LocalDate syncDate = LocalDate.now();
+
+		try {
+			// OpenAI 서버에서 누적 비용 조회
+			BigDecimal exactUsage = openAiUsageClient.fetchMonthlyTotalUsageAmount();
+
+			// 현재 연월 문자열 생성
+			String currentPeriod = YearMonth.now().toString();
+
+			// Redis에 저장된 기존 추정치를 정확한 값으로 갱신
+			llmUsageRedisDao.setUsage(currentPeriod, exactUsage);
+
+			log.info("[UsageSync] OpenAI LLM 비용 동기화 완료 (Date: {}, Period: {}, Exact Cost: ${})",
+				syncDate, currentPeriod, exactUsage);
+
+		} catch (Exception e) {
+			log.error("[UsageSync] OpenAI LLM 비용 동기화 실패 (Date: {}) - {}",
+				syncDate, e.getMessage(), e);
+		}
+	}
+}

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/usage/scheduler/UsageSyncScheduler.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/usage/scheduler/UsageSyncScheduler.java
@@ -3,6 +3,7 @@ package com.hallachatbot.backend.domain.usage.scheduler;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.YearMonth;
+import java.time.ZoneId;
 
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -33,14 +34,12 @@ public class UsageSyncScheduler {
 	 */
 	@Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
 	public void syncMonthlyLlmUsage() {
-		LocalDate syncDate = LocalDate.now();
+		LocalDate syncDate = LocalDate.now(ZoneId.of("Asia/Seoul"));
+		String currentPeriod = getCurrentPeriod();
 
 		try {
 			// OpenAI 서버에서 누적 비용 조회
 			BigDecimal exactUsage = openAiUsageClient.fetchMonthlyTotalUsageAmount();
-
-			// 현재 연월 문자열 생성
-			String currentPeriod = YearMonth.now().toString();
 
 			// Redis에 저장된 기존 추정치를 정확한 값으로 갱신
 			llmUsageRedisDao.setUsage(currentPeriod, exactUsage);
@@ -52,5 +51,10 @@ public class UsageSyncScheduler {
 			log.error("[UsageSync] OpenAI LLM 비용 동기화 실패 (Date: {}) - {}",
 				syncDate, e.getMessage(), e);
 		}
+	}
+
+	private String getCurrentPeriod() {
+		YearMonth currentMonth = YearMonth.now(ZoneId.of("Asia/Seoul"));
+		return currentMonth.toString();
 	}
 }

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/global/errorcode/UsageErrorCode.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/global/errorcode/UsageErrorCode.java
@@ -1,6 +1,7 @@
 package com.hallachatbot.backend.global.errorcode;
 
 import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
 import org.springframework.http.HttpStatus;
 
@@ -10,7 +11,7 @@ import lombok.RequiredArgsConstructor;
 /**
  * <b>비용(Cost) 도메인 관련 에러 코드 정의</b>
  * <p>
- * 비즈니스 로직 수행 중 발생하는 예외 상황을 체계적으로 관리하기 위한 Enum입니다.
+ * 비즈니스 로직 수행 중 발생하는 예외 상황을 체계적으로 관리하기 위한 Enum.
  * </p>
  */
 @Getter
@@ -21,7 +22,13 @@ public enum UsageErrorCode implements ErrorCode {
 	MONTHLY_LLM_BUDGET_EXCEEDED(
 		FORBIDDEN,
 		"이번 달 LLM 사용 한도를 초과하여 일시적으로 서비스 이용이 제한되었습니다.",
-		"LLM 예산 초과로 인한 이용 제한");
+		"LLM 예산 초과로 인한 이용 제한"),
+
+	// [500] 비용 조회 통합 에러
+	OPENAI_COST_FETCH_FAILED(
+		INTERNAL_SERVER_ERROR,
+		"OpenAI 비용 정보를 연동하는 데 실패했습니다.",
+		"OpenAI Cost API 통신 및 데이터 조회 실패");
 
 	private final HttpStatus status;
 	private final String message;

--- a/chatbot/backend/src/main/resources/application-test.yml
+++ b/chatbot/backend/src/main/resources/application-test.yml
@@ -1,0 +1,3 @@
+app:
+  costs-api-url: ${COSTS_API_URL:https://api.openai.com/v1/organization/costs}
+  openai-admin-key: ${OPENAI_ADMIN_KEY:dummy-key}

--- a/chatbot/backend/src/test/java/com/hallachatbot/backend/BackendApplicationTests.java
+++ b/chatbot/backend/src/test/java/com/hallachatbot/backend/BackendApplicationTests.java
@@ -2,7 +2,9 @@ package com.hallachatbot.backend;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class BackendApplicationTests {
 

--- a/chatbot/backend/src/test/java/com/hallachatbot/backend/domain/usage/client/OpenAiUsageClientTest.java
+++ b/chatbot/backend/src/test/java/com/hallachatbot/backend/domain/usage/client/OpenAiUsageClientTest.java
@@ -1,0 +1,126 @@
+package com.hallachatbot.backend.domain.usage.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.hallachatbot.backend.global.errorcode.UsageErrorCode;
+import com.hallachatbot.backend.global.exception.UsageException;
+
+@ExtendWith(MockitoExtension.class)
+class OpenAiUsageClientTest {
+
+	@Mock
+	private RestTemplateBuilder restTemplateBuilder;
+
+	@Mock
+	private RestTemplate restTemplate;
+
+	private OpenAiUsageClient openAiUsageClient;
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	@BeforeEach
+	void setUp() {
+		when(restTemplateBuilder.build()).thenReturn(restTemplate);
+		openAiUsageClient = new OpenAiUsageClient(
+			restTemplateBuilder,
+			"test-admin-key",
+			"https://api.openai.com/v1/organization/costs"
+		);
+	}
+
+	@Test
+	@DisplayName("당월 비용 조회 성공 - 유효한 JSON 데이터가 주어지면 금액을 합산하여 반환한다")
+	void fetchMonthlyTotalUsageAmount_Success() {
+		// given
+		ObjectNode rootNode = objectMapper.createObjectNode();
+		ArrayNode dataArray = rootNode.putArray("data");
+
+		ObjectNode bucket1 = dataArray.addObject();
+		ArrayNode results1 = bucket1.putArray("results");
+		results1.addObject().putObject("amount").put("value", 0.05);
+		results1.addObject().putObject("amount").put("value", 0.01);
+
+		ResponseEntity<JsonNode> responseEntity = new ResponseEntity<>(rootNode, HttpStatus.OK);
+		when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), any(), eq(JsonNode.class)))
+			.thenReturn(responseEntity);
+
+		// when
+		BigDecimal totalCost = openAiUsageClient.fetchMonthlyTotalUsageAmount();
+
+		// then
+		BigDecimal expected = new BigDecimal("0.06").setScale(6, RoundingMode.HALF_UP);
+		assertThat(totalCost).isEqualTo(expected);
+	}
+
+	@Test
+	@DisplayName("당월 비용 조회 성공 - 응답에 data 배열이 없으면 0.000000을 반환한다")
+	void fetchMonthlyTotalUsageAmount_EmptyData() {
+		// given
+		ObjectNode emptyNode = objectMapper.createObjectNode();
+		ResponseEntity<JsonNode> responseEntity = new ResponseEntity<>(emptyNode, HttpStatus.OK);
+
+		when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), any(), eq(JsonNode.class)))
+			.thenReturn(responseEntity);
+
+		// when
+		BigDecimal totalCost = openAiUsageClient.fetchMonthlyTotalUsageAmount();
+
+		// then
+		BigDecimal expected = new BigDecimal("0.000000");
+		// isEqualByComparingTo는 0과 0.000000을 같다고 판단합니다.
+		assertThat(totalCost).isEqualByComparingTo(expected);
+	}
+
+	@Test
+	@DisplayName("당월 비용 조회 실패 - 401 인증 에러 발생 시 UsageException을 던진다")
+	void fetchMonthlyTotalUsageAmount_Unauthorized() {
+		// given
+		when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), any(), eq(JsonNode.class)))
+			.thenThrow(new HttpClientErrorException(HttpStatus.UNAUTHORIZED));
+
+		// when & then (메시지 비교가 아닌 ErrorCode 일치 여부로 정확하게 검증)
+		assertThatThrownBy(() -> openAiUsageClient.fetchMonthlyTotalUsageAmount())
+			.isInstanceOf(UsageException.class)
+			.extracting(e -> ((UsageException) e).getErrorCode())
+			.isEqualTo(UsageErrorCode.OPENAI_COST_FETCH_FAILED);
+	}
+
+	@Test
+	@DisplayName("당월 비용 조회 실패 - 500 서버 에러 등 통신 장애 시 UsageException을 던진다")
+	void fetchMonthlyTotalUsageAmount_ServerError() {
+		// given
+		when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), any(), eq(JsonNode.class)))
+			.thenThrow(new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR));
+
+		// when & then
+		assertThatThrownBy(() -> openAiUsageClient.fetchMonthlyTotalUsageAmount())
+			.isInstanceOf(UsageException.class)
+			.extracting(e -> ((UsageException) e).getErrorCode())
+			.isEqualTo(UsageErrorCode.OPENAI_COST_FETCH_FAILED);
+	}
+}

--- a/chatbot/backend/src/test/java/com/hallachatbot/backend/domain/usage/scheduler/UsageSyncScheduler.java
+++ b/chatbot/backend/src/test/java/com/hallachatbot/backend/domain/usage/scheduler/UsageSyncScheduler.java
@@ -1,0 +1,81 @@
+package com.hallachatbot.backend.domain.usage.scheduler;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.hallachatbot.backend.domain.usage.client.OpenAiUsageClient;
+import com.hallachatbot.backend.domain.usage.dao.LlmUsageRedisDao;
+import com.hallachatbot.backend.global.errorcode.UsageErrorCode;
+import com.hallachatbot.backend.global.exception.UsageException;
+
+@ExtendWith(MockitoExtension.class)
+class UsageSyncSchedulerTest {
+
+	@Mock
+	private LlmUsageRedisDao llmUsageRedisDao;
+
+	@Mock
+	private OpenAiUsageClient openAiUsageClient;
+
+	@InjectMocks
+	private UsageSyncScheduler usageSyncScheduler;
+
+	@Test
+	@DisplayName("스케줄러 성공 - OpenAI 비용을 성공적으로 조회하여 Redis에 오버라이트한다")
+	void syncMonthlyLlmUsage_Success() {
+		// given
+		BigDecimal exactUsage = new BigDecimal("15.50");
+		when(openAiUsageClient.fetchMonthlyTotalUsageAmount()).thenReturn(exactUsage);
+
+		// when
+		usageSyncScheduler.syncMonthlyLlmUsage();
+
+		// then
+		// 1. Client 조회가 정상 호출되었는지 확인
+		verify(openAiUsageClient).fetchMonthlyTotalUsageAmount();
+
+		// 2. Dao의 setUsage가 호출되었는지 유연하게(any) 검증
+		// Mockito가 파라미터 미세 차이로 Zero Interactions를 띄우는 것을 방지
+		verify(llmUsageRedisDao).setUsage(anyString(), any(BigDecimal.class));
+	}
+
+	@Test
+	@DisplayName("스케줄러 실패 방어 - Client에서 통신 에러가 발생해도 로깅 후 안전하게 종료된다")
+	void syncMonthlyLlmUsage_ClientThrowsException() {
+		// given
+		when(openAiUsageClient.fetchMonthlyTotalUsageAmount())
+			.thenThrow(new UsageException(UsageErrorCode.OPENAI_COST_FETCH_FAILED));
+
+		// when (예외가 던져지지 않고 삼켜져야 함)
+		usageSyncScheduler.syncMonthlyLlmUsage();
+
+		// then (에러 발생 시 Redis 저장은 절대 호출되지 않아야 함)
+		verify(llmUsageRedisDao, never()).setUsage(anyString(), any());
+	}
+
+	@Test
+	@DisplayName("스케줄러 실패 방어 - 예상치 못한 시스템 에러(NPE 등)에도 스레드가 죽지 않는다")
+	void syncMonthlyLlmUsage_UnexpectedException() {
+		// given
+		when(openAiUsageClient.fetchMonthlyTotalUsageAmount())
+			.thenThrow(new NullPointerException("Unexpected Null"));
+
+		// when
+		usageSyncScheduler.syncMonthlyLlmUsage();
+
+		// then
+		verify(llmUsageRedisDao, never()).setUsage(anyString(), any());
+	}
+}


### PR DESCRIPTION
## 📌 Summary

* OpenAI Costs API를 이용하여 실제 LLM 사용 비용을 조회하고 Redis에 저장된 사용량을 동기화하는 기능을 추가

---

## 🎯 Background

* 현재 시스템은 LLM 사용량을 내부 로직으로 추정 계산하여 Redis에 저장하고 있음
* 그러나 실제 OpenAI 과금 데이터와 차이가 발생할 수 있어 정확한 비용 기준 보정 로직이 필요함
* 이를 위해 OpenAI Admin API의 Costs API를 호출하여 실제 비용을 조회하고 캐시 데이터를 동기화하도록 구현

---

## 🔨 Changes

* OpenAI 비용 조회 클라이언트 `OpenAiUsageClient` 구현

  * OpenAI Costs API 호출
  * 당월 1일 ~ 현재 기준 비용 조회
  * 응답 JSON 파싱 후 USD 총 비용 계산
* Redis 사용량 동기화 스케줄러 `UsageSyncScheduler` 구현

  * 매일 00시 OpenAI 실제 비용 조회
  * Redis에 저장된 LLM usage 값을 실제 비용으로 갱신
* 스케줄러 사용을 위한 `@EnableScheduling` 활성화
* API 호출 실패 시 `UsageException` 기반 예외 처리

---

## 🧪 Test & Verification

* [x] 로컬 환경에서 OpenAI Costs API 호출 확인
* [x] 정상 응답 시 Redis usage 값 갱신 확인
* [x] 스케줄러 실행 로그 확인

---

## ⚠️ Impact & Risk

* 영향 범위: LLM 사용량 비용 추적 및 Redis usage 캐시
* 리스크: OpenAI API 응답 실패 시 비용 동기화가 수행되지 않을 수 있음
* 롤백 방법:
  * `UsageSyncScheduler` 비활성화
  * 해당 스케줄러 및 클라이언트 코드 롤백

---

## 📝 Notes

* 비용 동기화는 **KST 기준 매일 00시** 실행됨

---

## 🔗 Related Issues

* Closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 매일 자정(한국 시간)에 OpenAI 사용량을 자동 동기화하는 스케줄링 기능 추가
  * OpenAI API에서 월별 누적 사용 비용을 조회하여 저장하는 기능 추가

* **Chores**
  * 애플리케이션 설정 업데이트로 스케줄링 활성화 및 관련 오류 코드/로그 메시지 확장

* **Tests**
  * 비용 조회 및 동기화 로직에 대한 단위 테스트 추가 (성공/오류/예외 시나리오)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->