### PR TITLE
AWS ElastiCache 도입 및 배포 환경 고도화

### DIFF
--- a/chatbot/backend/.gitignore
+++ b/chatbot/backend/.gitignore
@@ -37,7 +37,7 @@ out/
 .vscode/
 
 # ===============================추가 내용=================================
-src/main/resources/application-secret.yml
+src/main/resources/application-local.yml
 .env
 .env.*
 *.key

--- a/chatbot/backend/build.gradle
+++ b/chatbot/backend/build.gradle
@@ -82,6 +82,9 @@ dependencies {
     testImplementation 'io.projectreactor:reactor-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
+
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-parameter-store:3.1.1'
 }
 
 tasks.named('test') {

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/global/config/MongoConfig.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/global/config/MongoConfig.java
@@ -1,4 +1,4 @@
-package com.hallachatbot.backend.global.db.mongodb;
+package com.hallachatbot.backend.global.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.config.EnableMongoAuditing;

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/global/config/RedisConfig.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/global/config/RedisConfig.java
@@ -1,0 +1,117 @@
+package com.hallachatbot.backend.global.config;
+
+import java.time.Duration;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.connection.RedisClusterConfiguration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import io.lettuce.core.cluster.ClusterClientOptions;
+import io.lettuce.core.cluster.ClusterTopologyRefreshOptions;
+
+/**
+ * <b>Redis (AWS ElastiCache 호환) 전역 설정 클래스</b>
+ *
+ * <p>
+ * 애플리케이션의 실행 환경(Profile)에 따라 Redis 연결 방식을 동적으로 구성합니다.
+ * 운영 및 스테이징 환경에서는 클러스터 모드를 사용하며,
+ * 로컬 개발 환경에서는 가벼운 단일 모드를 사용.
+ * </p>
+ */
+@Configuration
+public class RedisConfig {
+
+	/**
+	 * 운영 및 스테이징 환경용 Redis Cluster 커넥션 팩토리 빈을 생성.
+	 * <p>
+	 * <b>주요 설정 요소:</b>
+	 * <ul>
+	 * <li><b>Topology Refresh:</b> AWS ElastiCache(Valkey/Redis)의 노드 장애나 스케일 아웃 등으로 인한
+	 * Failover 발생 시, 애플리케이션 재시작 없이 클러스터 맵을 자동으로 갱신.</li>
+	 * <li><b>SSL 적용:</b> AWS 인프라의 '전송 중 암호화' 설정에 대응하기 위해 TLS 통신을 활성화.</li>
+	 * </ul>
+	 * </p>
+	 *
+	 * @param clusterNodes 환경변수 또는 Parameter Store를 통해 주입받은 클러스터 구성 엔드포인트 목록
+	 * @return 자동 갱신 및 SSL 옵션이 적용된 {@link LettuceConnectionFactory} 객체
+	 */
+	@Bean
+	@Profile({"stg", "prod"})
+	public RedisConnectionFactory clusterRedisConnectionFactory(
+		@Value("${spring.data.redis.cluster.nodes}") List<String> clusterNodes) {
+
+		RedisClusterConfiguration clusterConfig = new RedisClusterConfiguration(clusterNodes);
+
+		// AWS 클러스터 노드 변경 시 자동으로 연결을 갱신
+		ClusterTopologyRefreshOptions refreshOptions = ClusterTopologyRefreshOptions.builder()
+			.enablePeriodicRefresh(Duration.ofMinutes(10))
+			.enableAllAdaptiveRefreshTriggers()
+			.build();
+
+		ClusterClientOptions clientOptions = ClusterClientOptions.builder()
+			.topologyRefreshOptions(refreshOptions)
+			.build();
+
+		// 클라이언트 설정에 Refresh Options와 SSL 보안 적용
+		LettuceClientConfiguration clientConfig = LettuceClientConfiguration.builder()
+			.clientOptions(clientOptions)
+			.useSsl()
+			.build();
+
+		return new LettuceConnectionFactory(clusterConfig, clientConfig);
+	}
+
+	/**
+	 * 로컬 개발 환경용 Redis Standalone 커넥션 팩토리 빈을 생성.
+	 *
+	 * <p>
+	 * 클러스터 토폴로지 갱신이나 SSL 암호화 등 무거운 설정 없이,
+	 * Docker 등으로 띄운 로컬 단일 Redis 인스턴스에 빠르게 연결하기 위해 사용.
+	 * </p>
+	 *
+	 * @param host Redis 서버 호스트 주소
+	 * @param port Redis 서버 포트
+	 * @return 단일 노드 연결 옵션이 적용된 {@link LettuceConnectionFactory} 객체
+	 */
+	@Bean
+	@Profile("!stg && !prod")
+	public RedisConnectionFactory standaloneRedisConnectionFactory(
+		@Value("${spring.data.redis.host}") String host,
+		@Value("${spring.data.redis.port}") int port) {
+
+		return new LettuceConnectionFactory(new RedisStandaloneConfiguration(host, port));
+	}
+
+	/**
+	 * 애플리케이션에서 Redis 데이터를 직렬화 및 역직렬화하기 위한 템플릿 빈을 생성.
+	 * * <p>
+	 * 스프링의 기본 직렬화 방식은 데이터를 이진 형태로 저장하여
+	 * 직접 조회 시 가독성이 떨어지고, 다른 언어/플랫폼과의 데이터 호환이 어려움.
+	 * 이를 해결하기 위해 Key는 문자열로, Value는 범용적인 JSON 형태로 변환하여 저장.
+	 * </p>
+	 *
+	 * @param connectionFactory 현재 활성화된 프로파일에 따라 주입된 커넥션 팩토리
+	 * @return 커스텀 직렬화 설정이 완료된 {@link RedisTemplate} 객체
+	 */
+	@Bean
+	public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+		RedisTemplate<String, Object> template = new RedisTemplate<>();
+		template.setConnectionFactory(connectionFactory);
+
+		// 사람이 직접 읽을 수 있는 형태로 데이터 직렬화
+		template.setKeySerializer(new StringRedisSerializer());
+		template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+		return template;
+	}
+}

--- a/chatbot/backend/src/main/resources/application-prod.yml
+++ b/chatbot/backend/src/main/resources/application-prod.yml
@@ -1,0 +1,13 @@
+spring:
+  data:
+    redis:
+      cluster:
+        nodes: ${REDIS_CLUSTER_NODES}
+      ssl:
+        enabled: true
+
+springdoc:
+  api-docs:
+    enabled: false
+  swagger-ui:
+    enabled: false

--- a/chatbot/backend/src/main/resources/application-stg.yml
+++ b/chatbot/backend/src/main/resources/application-stg.yml
@@ -1,0 +1,13 @@
+spring:
+  data:
+    redis:
+      cluster:
+        nodes: ${REDIS_CLUSTER_NODES}
+      ssl:
+        enabled: true
+
+springdoc:
+  api-docs:
+    enabled: false
+  swagger-ui:
+    enabled: false


### PR DESCRIPTION
## 📌 Summary
- AWS 운영 환경 최적화를 위한 프로파일 분리 및 ElastiCache(Valkey) 클러스터 설정 도입
- 설정값 자동화

---

## 🎯 Background
- **고가용성 확보**: AWS ElastiCache의 노드 장애 발생 시에도 서비스 중단 없는 자동 연결 갱신(Topology Refresh) 필요
- **환경별 최적화**: 로컬 개발의 편의성(Standalone)과 운영 환경의 안정성(Cluster)을 프로파일별로 분리하여 관리
- **보안 및 규정 준수**: 민감한 설정값의 로컬 노출 방지 및 운영 환경 Swagger 비활성화

---

## 🔨 Changes

### 1. 배포 환경 분리 및 인프라 연동
- **환경별 프로파일 확장**: `application-stg.yml`, `application-prod.yml` 추가
- **Spring Cloud AWS 도입**: AWS Parameter Store(SSM)와 설정값 자동 연동 (`spring-cloud-aws-starter-parameter-store`)
- **Actuator 추가**: ALB(Load Balancer)의 헬스체크 및 인프라 상태 모니터링을 위한 `spring-boot-starter-actuator` 도입
- **보안 강화**: `.gitignore` 수정 및 로컬 비밀 설정 파일명을 `application-local.yml`로 표준화

### 2. Redis(Valkey) 설정 고도화
- **프로파일 기반 분기**: `@Profile`을 이용해 로컬(Standalone)과 배포판(Cluster) 커넥션 팩토리 자동 선택
- **클러스터 안정성 설정**: `Topology Refresh` 옵션 적용 (10분 주기 및 장애 발생 시 즉시 갱신)
- **보안 통신**: AWS 전송 중 암호화 옵션에 대응하는 `SSL/TLS` 활성화
- **데이터 직렬화 개선**: 기본 JDK 방식에서 JSON 방식(`GenericJackson2JsonRedisSerializer`)으로 변경하여 가독성 및 호환성 확보

### 3. 리팩토링
- **패키지 구조 정리**: `MongoConfig`를 `global/DB`에서 `global/config`로 이동하여 설정 클래스 응집도 향상

---

## 🧪 Test & Verification
- [x] `local` 프로파일 실행 시 Docker Redis(Standalone) 정상 연결 확인
- [x] `stg`, `prod` 프로파일 활성화 시 클러스터 전용 빈(Bean) 생성 여부 검증

---

## ⚠️ Impact & Risk
- **Parameter Store 의존성**: 배포 환경에서 `REDIS_CLUSTER_NODES` 등 필수 파라미터가 SSM에 등록되어 있지 않으면 구동 시 에러 발생 가능
- **네트워크 보안**: AWS 보안 그룹(Security Group)에서 6379 포트가 ECS -> ElastiCache 방향으로 허용되어 있는지 확인 필요

---

## 📝 Notes
- 이제 `task-def.json`에 일일이 Secret을 적지 않아도 스프링이 Parameter Store에서 직접 값을 긁어옵니다.
- `application-local.yml`은 절대 커밋되지 않도록 주의해 주세요.

---

## 🔗 Related Issues
- Closes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * Redis 클러스터 지원 추가 (프로덕션 및 스테이징 환경)
  * 애플리케이션 모니터링 기능 추가

* **Refactor**
  * 내부 구조 정리 및 설정 모듈화

* **Chores**
  * 환경별 설정 파일 개선
  * AWS 파라미터 스토어 연동 지원 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->