### PR TITLE
당월 누적 사용량 반영 로직 적용

### DIFF
--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/service/ChatService.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/service/ChatService.java
@@ -20,6 +20,7 @@ import com.hallachatbot.backend.global.sse.SseEventFactory;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
 /**
@@ -64,6 +65,7 @@ public class ChatService {
 	 * @param chatId 사용자 식별을 위한 세션 ID (쿠키)
 	 * @return 클라이언트로 전송될 Server-Sent Events 스트림
 	 */
+	@SuppressWarnings("checkstyle:Indentation")
 	public Flux<ServerSentEvent<String>> startChat(ChatRequest request, String chatId) {
 		// 1. 비용 한도 확인
 		usageService.checkMonthlyLlmUsage();
@@ -77,22 +79,22 @@ public class ChatService {
 		// 3. AI 서비스 호출 및 스트리밍 변환
 		Flux<ServerSentEvent<String>> eventFlux = aiServiceClient.streamChat(request, history)
 			.map(aiResponse -> chatStreamHandler.processAiResponse(aiResponse, context))
-			.onErrorResume(chatStreamErrorHandler::handleStreamError)
-			.doOnComplete(() -> {
-				// 저장 로직 비동기 실행
-				if (context.hasAnswer()) {
-					Flux.just(context)
-						.publishOn(Schedulers.boundedElastic())
-						.subscribe(ctx -> {
-							// 대화 데이터 DB 저장
-							chatWriter.saveChatData(ctx);
+			.onErrorResume(chatStreamErrorHandler::handleStreamError).doOnComplete(() -> {
 
-							// 메타데이터에서 추출한 달러 비용이 0보다 크면 사용량 누적
-							if (ctx.getCost() != null && ctx.getCost().compareTo(BigDecimal.ZERO) > 0) {
-								usageService.addMonthlyLlmUsage(ctx.getCost());
-							}
-						});
+				// 저장 로직 비동기 실행
+				// @formatter:off
+				if (context.hasAnswer()) {
+					Mono.fromRunnable(() -> {
+						chatWriter.saveChatData(context);
+
+						if (context.getCost() != null && context.getCost().compareTo(BigDecimal.ZERO) > 0) {
+							usageService.addMonthlyLlmUsage(context.getCost());
+						}
+					})
+					.subscribeOn(Schedulers.boundedElastic())
+					.doOnError(e -> log.error("채팅 후처리 실패: chatId={}", context.getChatId(), e)).subscribe();
 				}
+				// @formatter:on
 			});
 
 		// 4. 초기 이벤트 주입 (Metadata, Warning)

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/service/ChatService.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/service/ChatService.java
@@ -91,8 +91,9 @@ public class ChatService {
 							usageService.addMonthlyLlmUsage(context.getCost());
 						}
 					})
-					.subscribeOn(Schedulers.boundedElastic())
-					.doOnError(e -> log.error("채팅 후처리 실패: chatId={}", context.getChatId(), e)).subscribe();
+						.subscribeOn(Schedulers.boundedElastic())
+						.subscribe(null, e -> log.error("채팅 후처리 실패: chatId={}", context.getChatId(), e)
+						);
 				}
 				// @formatter:on
 			});

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/service/ChatService.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/service/ChatService.java
@@ -1,5 +1,6 @@
 package com.hallachatbot.backend.domain.chat.service;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 
@@ -82,7 +83,15 @@ public class ChatService {
 				if (context.hasAnswer()) {
 					Flux.just(context)
 						.publishOn(Schedulers.boundedElastic())
-						.subscribe(chatWriter::saveChatData);
+						.subscribe(ctx -> {
+							// 대화 데이터 DB 저장
+							chatWriter.saveChatData(ctx);
+
+							// 메타데이터에서 추출한 달러 비용이 0보다 크면 사용량 누적
+							if (ctx.getCost() != null && ctx.getCost().compareTo(BigDecimal.ZERO) > 0) {
+								usageService.addMonthlyLlmUsage(ctx.getCost());
+							}
+						});
 				}
 			});
 

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/service/ChatService.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/service/ChatService.java
@@ -79,24 +79,31 @@ public class ChatService {
 		// 3. AI 서비스 호출 및 스트리밍 변환
 		Flux<ServerSentEvent<String>> eventFlux = aiServiceClient.streamChat(request, history)
 			.map(aiResponse -> chatStreamHandler.processAiResponse(aiResponse, context))
-			.onErrorResume(chatStreamErrorHandler::handleStreamError).doOnComplete(() -> {
-
+			.doOnComplete(() -> {
 				// 저장 로직 비동기 실행
 				// @formatter:off
 				if (context.hasAnswer()) {
 					Mono.fromRunnable(() -> {
-						chatWriter.saveChatData(context);
+						try {
+							chatWriter.saveChatData(context);
+						} catch (Exception e) {
+							log.error("채팅 대화 내역 DB 저장 실패: chatId={}", context.getChatId(), e);
+						}
 
-						if (context.getCost() != null && context.getCost().compareTo(BigDecimal.ZERO) > 0) {
-							usageService.addMonthlyLlmUsage(context.getCost());
+						try {
+							if (context.getCost() != null && context.getCost().compareTo(BigDecimal.ZERO) > 0) {
+								usageService.addMonthlyLlmUsage(context.getCost());
+							}
+						} catch (Exception e) {
+							log.error("월간 LLM 비용 누적 실패: chatId={}", context.getChatId(), e);
 						}
 					})
 						.subscribeOn(Schedulers.boundedElastic())
-						.subscribe(null, e -> log.error("채팅 후처리 실패: chatId={}", context.getChatId(), e)
-						);
+						.subscribe();
 				}
 				// @formatter:on
-			});
+			})
+			.onErrorResume(chatStreamErrorHandler::handleStreamError);
 
 		// 4. 초기 이벤트 주입 (Metadata, Warning)
 		return injectInitialEvents(eventFlux, chatId);

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/service/ChatStreamContext.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/service/ChatStreamContext.java
@@ -52,10 +52,6 @@ public class ChatStreamContext {
 		return this.answerBuilder.length() > 0;
 	}
 
-	public BigDecimal getCost() {
-		return this.cost;
-	}
-
 	/**
 	 * 메타데이터 갱신 및 주요 정보(토큰, RAG 사유) 추출
 	 *

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/service/ChatStreamContext.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/service/ChatStreamContext.java
@@ -90,7 +90,9 @@ public class ChatStreamContext {
 				}
 			}
 
+			this.cost = BigDecimal.ZERO;
 			Object costObj = null;
+
 			for (Map.Entry<?, ?> entry : usage.entrySet()) {
 				String key = String.valueOf(entry.getKey()).trim();
 				if ("total_cost_usd".equals(key)) {

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/service/ChatStreamContext.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/service/ChatStreamContext.java
@@ -1,5 +1,6 @@
 package com.hallachatbot.backend.domain.chat.service;
 
+import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -27,6 +28,7 @@ public class ChatStreamContext {
 	private final String question;
 	private final StringBuilder answerBuilder = new StringBuilder();
 	private Map<String, Object> metadataMap = new HashMap<>();
+	private BigDecimal cost = BigDecimal.ZERO;
 
 	// 추출된 주요 메타데이터
 	private String decision = "";
@@ -50,6 +52,10 @@ public class ChatStreamContext {
 		return this.answerBuilder.length() > 0;
 	}
 
+	public BigDecimal getCost() {
+		return this.cost;
+	}
+
 	/**
 	 * 메타데이터 갱신 및 주요 정보(토큰, RAG 사유) 추출
 	 *
@@ -68,7 +74,7 @@ public class ChatStreamContext {
 			this.decision = gateReason != null ? gateReason.toString() : "";
 		}
 
-		// Token Usage 추출
+		// Token Usage & total_cost_usd 추출
 		if (data.get("token_usage") instanceof Map<?, ?> usage) {
 			Object presetObj = usage.get("preset");
 			this.preset = presetObj != null ? presetObj.toString() : "";
@@ -81,6 +87,23 @@ public class ChatStreamContext {
 					this.totalTokens = Integer.parseInt(s);
 				} catch (NumberFormatException e) {
 					this.totalTokens = 0;
+				}
+			}
+
+			Object costObj = null;
+			for (Map.Entry<?, ?> entry : usage.entrySet()) {
+				String key = String.valueOf(entry.getKey()).trim();
+				if ("total_cost_usd".equals(key)) {
+					costObj = entry.getValue();
+					break;
+				}
+			}
+
+			if (costObj != null) {
+				try {
+					this.cost = new BigDecimal(costObj.toString());
+				} catch (NumberFormatException e) {
+					this.cost = BigDecimal.ZERO;
 				}
 			}
 		}

--- a/chatbot/backend/src/test/java/com/hallachatbot/backend/domain/chat/service/ChatServiceTest.java
+++ b/chatbot/backend/src/test/java/com/hallachatbot/backend/domain/chat/service/ChatServiceTest.java
@@ -8,11 +8,15 @@ import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.math.BigDecimal;
 import java.util.Collections;
+import java.util.Map;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -203,5 +207,51 @@ class ChatServiceTest {
 
 		// ChatWriter(저장 담당)가 호출되었는지 검증
 		verify(chatWriter, timeout(1000).times(1)).saveChatData(any());
+	}
+
+	@Test
+	@DisplayName("스트리밍이 정상 종료되고 비용이 0보다 크면 UsageService가 비동기로 호출되어야 한다.")
+	void startChat_CallsUsageService_WhenCostIsGreaterThanZero() {
+		// given
+		String chatId = "test-chat-session";
+		ChatRequest request = new ChatRequest("안녕", ChatRequest.Language.KOR);
+
+		// 의존성 Mocking 세팅
+		doNothing().when(usageService).checkMonthlyLlmUsage();
+		when(chatReader.getChatHistory(chatId)).thenReturn(Collections.emptyList());
+		when(sseEventFactory.createMetadata(any())).thenReturn(
+			ServerSentEvent.<String>builder().event("metadata").build());
+
+		// AI 서비스 응답 조작 (비용이 포함된 메타데이터 응답을 시뮬레이션)
+		AiServiceResponse fakeDelta = new AiServiceResponse("delta", "반가워요", null, null, null);
+		AiServiceResponse fakeMeta = new AiServiceResponse("metadata", null,
+			Map.of("token_usage", Map.of("total_cost_usd", "0.0055")), null, null);
+
+		when(aiServiceClient.streamChat(eq(request), anyList())).thenReturn(Flux.just(fakeDelta, fakeMeta));
+
+		// Handler가 Context를 업데이트 하도록 조작
+		when(chatStreamHandler.processAiResponse(any(), any())).thenAnswer(invocation -> {
+			AiServiceResponse resp = invocation.getArgument(0);
+			ChatStreamContext ctx = invocation.getArgument(1);
+			if ("delta".equals(resp.type())) {
+				ctx.appendAnswer(resp.content());
+			}
+			if ("metadata".equals(resp.type())) {
+				ctx.updateMetadata(resp.data());
+			}
+			return ServerSentEvent.<String>builder().build();
+		});
+
+		// when
+		Flux<ServerSentEvent<String>> resultFlux = chatService.startChat(request, chatId);
+
+		// then
+		StepVerifier.create(resultFlux)
+			.expectNextCount(3) // 초기 메타데이터 1개 + delta 1개 + meta 1개
+			.verifyComplete();
+
+		// Schedulers.boundedElastic()을 타고 비동기로 실행되므로 timeout으로 대기 후 검증
+		verify(chatWriter, timeout(1000).times(1)).saveChatData(any(ChatStreamContext.class));
+		verify(usageService, timeout(1000).times(1)).addMonthlyLlmUsage(any(BigDecimal.class));
 	}
 }

--- a/chatbot/backend/src/test/java/com/hallachatbot/backend/domain/chat/service/ChatStreamContextTest.java
+++ b/chatbot/backend/src/test/java/com/hallachatbot/backend/domain/chat/service/ChatStreamContextTest.java
@@ -1,0 +1,53 @@
+package com.hallachatbot.backend.domain.chat.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ChatStreamContextTest {
+
+	@Test
+	@DisplayName("total_cost_usd 키에 공백이 포함되어 있어도 비용이 정상적으로 추출되어야 한다.")
+	void updateMetadata_ExtractCostWithTrailingSpace() {
+		// given
+		ChatStreamContext context = new ChatStreamContext("chat-123", "테스트 질문");
+
+		Map<String, Object> tokenUsage = new HashMap<>();
+		tokenUsage.put("total_cost_usd ", 0.0073355);
+		tokenUsage.put("total_tokens", 100);
+
+		Map<String, Object> metadata = new HashMap<>();
+		metadata.put("token_usage", tokenUsage);
+
+		// when
+		context.updateMetadata(metadata);
+
+		// then
+		assertThat(context.getCost()).isEqualByComparingTo(new BigDecimal("0.0073355"));
+		assertThat(context.getTotalTokens()).isEqualTo(100);
+	}
+
+	@Test
+	@DisplayName("비용 정보가 없거나 변환할 수 없는 값일 경우 비용은 ZERO를 유지해야 한다.")
+	void updateMetadata_CostIsZeroWhenNullOrInvalid() {
+		// given
+		ChatStreamContext context = new ChatStreamContext("chat-123", "테스트 질문");
+
+		Map<String, Object> tokenUsage = new HashMap<>();
+		tokenUsage.put("total_cost_usd", null);
+
+		Map<String, Object> metadata = new HashMap<>();
+		metadata.put("token_usage", tokenUsage);
+
+		// when
+		context.updateMetadata(metadata);
+
+		// then
+		assertThat(context.getCost()).isEqualByComparingTo(BigDecimal.ZERO);
+	}
+}


### PR DESCRIPTION
## 📌 Summary
<!-- 이 PR이 무엇을 하는지 한 줄로 요약 -->
- AI 챗봇 응답 완료 시 메타데이터에서 사용 비용(USD)을 추출하여 당월 누적 사용량에 반영하는 로직 추가

---

## 🎯 Background
<!-- 왜 이 변경이 필요한지 (이슈, 요구사항, 맥락) -->
- AI 서버에서 스트리밍 메타데이터 응답 시 `token_usage` 내부에 `total_cost_usd`로 달러 기준 사용 금액을 계산하여 내려주고 있음.
- chat 도메인 내에서 `UsageService`를 호출하여 실시간 예산 통제 및 과금 누적을 처리해야 함.
---

## 🔨 Changes
<!-- 주요 변경 사항을 구체적으로 -->
- `ChatStreamContext.java` 수정:
   - 메타데이터 파싱 시 `token_usage` 맵을 순회하며 `.trim()`으로 키의 공백을 제거하여 방어적으로 `total_cost_usd` 값을 추출하는 로직 구현.
   - 추출된 비용을 담을 `BigDecimal cost` 필드 및 Getter 추가.
- `ChatService.java` 수정:
   - `startChat` 메서드의 스트리밍 완료(`doOnComplete`) 블록 내에서 `ChatWriter`를 통한 DB 저장 직후 로직 추가.
   - 추출된 비용이 0보다 크면 비동기 스레드에서 `usageService.addMonthlyLlmUsage(cost)`를 호출하도록 파이프라인 수정.
- 테스트 코드 추가/수정:
   - `ChatStreamContextTest`: 공백이 포함된 키값 추출 방어 로직 정상 작동 검증 및 null 값 처리 테스트 추가.
   - `ChatServiceTest`: 비용이 0보다 클 때 UsageService가 비동기로 올바르게 호출되는지 검증 로직 추가.
---

## 🧪 Test & Verification
<!-- 어떻게 검증했는지 -->
- [ x ] 로컬 테스트 완료
- [ x ] QA 시나리오 확인
- [ x ] 기존 기능 영향도 확인

<img width="2025" height="313" alt="화면 캡처 2026-03-09 200942" src="https://github.com/user-attachments/assets/5e21bd8d-7469-4fa0-862d-058ce12ce154" />
<img width="1098" height="145" alt="화면 캡처 2026-03-09 201507" src="https://github.com/user-attachments/assets/745f3f0e-a611-4d6e-90ac-e6ef4bc9283e" />

---

## ⚠️ Impact & Risk
<!-- 배포 시 영향 / 주의사항 / 롤백 포인트 -->
- 영향 범위: 채팅 스트리밍 완료 후 동작하는 비동기 DB 저장 및 외부 캐시(Redis) 갱신 파이프라인
- 리스크: AI 서버의 메타데이터 응답 포맷이 완전히 변경되거나 token_usage 구조가 바뀔 경우 비용 추출이 누락될 수 있음 (이 경우 예외가 발생하지 않고 0달러로 처리됨).
- 롤백 방법: `ChatService.java` 및 `ChatStreamContext.java`의 이전 커밋으로 롤백.

---

## 📝 Notes
<!-- 리뷰어가 알면 좋은 추가 정보 -->
- AI 파이썬 서버에서 JSON을 생성할 때 "total_cost_usd " 처럼 보이지 않는 공백이 포함되어 내려오는 구조로 작성되어 있습니다. 만약 이 구조가 수정된다면, `ChatStreamContext.java`의 복잡한 순회 로직을 지우고`usage.get("total_cost_usd")` 한 줄로 리팩토링 가능합니다.
---

## 🔗 Related Issues
<!-- 관련 이슈 -->
- Closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * LLM 비용 추적을 위한 필드 추가 및 스트리밍 응답에서 비용(total_cost_usd) 자동 추출
  * 비용이 존재할 경우 대화 데이터 저장과 함께 비용 기반 월간 사용량이 비동기적으로 등록되도록 처리 개선

* **테스트**
  * 비용 기반 사용량 서비스 호출 검증 테스트 추가
  * 비용 메타데이터 파싱(유효/무효 값 및 공백 키 처리) 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->