### PR TITLE
 AI 스트리밍 통신 로그에 세션 식별자 추가

### DIFF
--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/client/service/AiServiceClient.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/client/service/AiServiceClient.java
@@ -32,5 +32,5 @@ public interface AiServiceClient {
 	 * @param history 대화 문맥 유지를 위한 과거 메시지 리스트
 	 * @return AI 응답 객체 스트림 (Flux&lt;AiServiceResponse&gt;)
 	 */
-	Flux<AiServiceResponse> streamChat(ChatRequest request, List<ChatHistoryResponse> history);
+	Flux<AiServiceResponse> streamChat(String chatId, ChatRequest request, List<ChatHistoryResponse> history);
 }

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/client/service/AiServiceClientImpl.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/client/service/AiServiceClientImpl.java
@@ -55,7 +55,7 @@ public class AiServiceClientImpl implements AiServiceClient {
 	 * 4. 첫 번째 데이터(Delta) 수신 시점과 완료 시점의 소요 시간을 계산하여 로깅
 	 * </p>
 	 */
-	public Flux<AiServiceResponse> streamChat(ChatRequest request, List<ChatHistoryResponse> history) {
+	public Flux<AiServiceResponse> streamChat(String chatId, ChatRequest request, List<ChatHistoryResponse> history) {
 		String endpoint = aiServiceUrl + "/api/chat";
 
 		AiChatRequest aiBody = new AiChatRequest(
@@ -81,22 +81,24 @@ public class AiServiceClientImpl implements AiServiceClient {
 				if ("delta".equals(response.type()) && !firstTokenReceived.get() && response.content() != null) {
 					firstTokenReceived.set(true);
 					double durationSeconds = (System.nanoTime() - startTime) / 1_000_000_000.0;
-					log.info("[AI] 첫 응답(TTFT) 수신 성공 (Duration: {}초, FirstToken: {})",
-						String.format("%.4f", durationSeconds), response.content());
+					log.info("[AI] 스트리밍 첫 응답 수신 성공 (ChatId: {}, Duration: {}초)",
+						chatId, String.format("%.4f", durationSeconds));
 				}
 			})
 			.doOnComplete(() -> {
 				// 전체 완료 시간 로깅
 				double totalDuration = (System.nanoTime() - startTime) / 1_000_000_000.0;
-				log.info("[AI] 스트리밍 응답 완료 (TotalDuration: {}초)", String.format("%.4f", totalDuration));
+				log.info("[AI] 스트리밍 응답 완료 (ChatId: {}, TotalDuration: {}초, HistorySize: {})",
+					chatId, String.format("%.4f", totalDuration), history.size());
 			})
 			.doOnError(WebClientResponseException.class, e -> {
-				log.error("[AI] HTTP 통신 에러 발생 (Status: {}, ResponseBody: {})",
-					e.getStatusCode(), e.getResponseBodyAsString());
+				log.error("[AI] HTTP 통신 에러 발생 (ChatId: {}, Status: {}, ResponseBody: {})",
+					chatId, e.getStatusCode(), e.getResponseBodyAsString());
 			})
 			.doOnError(e -> {
 				if (!(e instanceof WebClientResponseException)) {
-					log.error("[AI] 스트리밍 중 예상치 못한 오류 발생 (Message: {})", e.getMessage(), e);
+					log.error("[AI] 스트리밍 중 예상치 못한 오류 발생 (ChatId: {}, Message: {})",
+						chatId, e.getMessage(), e);
 				}
 			});
 	}

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/service/ChatService.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/domain/chat/service/ChatService.java
@@ -77,7 +77,7 @@ public class ChatService {
 		ChatStreamContext context = new ChatStreamContext(chatId, request.userInput());
 
 		// 3. AI 서비스 호출 및 스트리밍 변환
-		Flux<ServerSentEvent<String>> eventFlux = aiServiceClient.streamChat(request, history)
+		Flux<ServerSentEvent<String>> eventFlux = aiServiceClient.streamChat(chatId, request, history)
 			.map(aiResponse -> chatStreamHandler.processAiResponse(aiResponse, context))
 			.doOnComplete(() -> {
 				// 저장 로직 비동기 실행

--- a/chatbot/backend/src/test/java/com/hallachatbot/backend/domain/chat/client/service/AiServiceClientTest.java
+++ b/chatbot/backend/src/test/java/com/hallachatbot/backend/domain/chat/client/service/AiServiceClientTest.java
@@ -54,6 +54,7 @@ class AiServiceClientTest {
 	@DisplayName("AI 서비스가 정상적으로 스트리밍 응답을 반환한다")
 	void streamChat_Success() throws Exception {
 		// given
+		String chatId = "test-chat-id";
 		ChatRequest request = new ChatRequest("질문", ChatRequest.Language.KOR);
 
 		// Mock Server 응답 설정 (NDJSON 형태 시뮬레이션)
@@ -68,8 +69,8 @@ class AiServiceClientTest {
 			.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
 			.setBody(responseBody));
 
-		// when
-		Flux<AiServiceResponse> responseFlux = aiServiceClient.streamChat(request, Collections.emptyList());
+		// when (chatId 매개변수 추가)
+		Flux<AiServiceResponse> responseFlux = aiServiceClient.streamChat(chatId, request, Collections.emptyList());
 
 		// then
 		StepVerifier.create(responseFlux)
@@ -97,10 +98,11 @@ class AiServiceClientTest {
 			.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
 			.setBody("{\"error\": \"Bad Request\"}"));
 
+		String chatId = "test-chat-id";
 		ChatRequest request = new ChatRequest("질문", ChatRequest.Language.KOR);
 
-		// when
-		Flux<AiServiceResponse> responseFlux = aiServiceClient.streamChat(request, Collections.emptyList());
+		// when (chatId 매개변수 추가)
+		Flux<AiServiceResponse> responseFlux = aiServiceClient.streamChat(chatId, request, Collections.emptyList());
 
 		// then: 에러가 발생해야 하며, doOnError(WebClientResponseException) 로직이 타게 됨
 		StepVerifier.create(responseFlux)
@@ -117,10 +119,11 @@ class AiServiceClientTest {
 			.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
 			.setBody("{invalid-json-body...}"));
 
+		String chatId = "test-chat-id";
 		ChatRequest request = new ChatRequest("질문", ChatRequest.Language.KOR);
 
-		// when
-		Flux<AiServiceResponse> responseFlux = aiServiceClient.streamChat(request, Collections.emptyList());
+		// when (chatId 매개변수 추가)
+		Flux<AiServiceResponse> responseFlux = aiServiceClient.streamChat(chatId, request, Collections.emptyList());
 
 		// then: JSON 디코딩 실패로 에러 발생 (doOnError의 '그 외 에러' 로직 커버)
 		StepVerifier.create(responseFlux)

--- a/chatbot/backend/src/test/java/com/hallachatbot/backend/domain/chat/service/ChatServiceTest.java
+++ b/chatbot/backend/src/test/java/com/hallachatbot/backend/domain/chat/service/ChatServiceTest.java
@@ -84,8 +84,8 @@ class ChatServiceTest {
 			.isInstanceOf(UsageException.class)
 			.hasFieldOrPropertyWithValue("errorCode", UsageErrorCode.MONTHLY_LLM_BUDGET_EXCEEDED);
 
-		// AI 서비스는 호출되지 않아야 함
-		verify(aiServiceClient, never()).streamChat(any(), any());
+		// AI 서비스는 호출되지 않아야 함 (매개변수 3개로 수정)
+		verify(aiServiceClient, never()).streamChat(any(), any(), any());
 	}
 
 	@Test
@@ -107,8 +107,8 @@ class ChatServiceTest {
 		// 3. AI 응답 및 핸들러 Mock
 		AiServiceResponse deltaResponse = new AiServiceResponse("delta", "반갑습니다.", null, null, null);
 
-		// 4. AI 클라이언트가 응답을 방출
-		given(aiServiceClient.streamChat(any(ChatRequest.class), anyList()))
+		// 4. AI 클라이언트가 응답을 방출 (chatId 매개변수 추가)
+		given(aiServiceClient.streamChat(any(), any(ChatRequest.class), anyList()))
 			.willReturn(Flux.just(deltaResponse));
 
 		// 5. ChatStreamHandler가 null이 아닌 SSE 이벤트를 반환하도록 Stubbing 추가
@@ -167,8 +167,8 @@ class ChatServiceTest {
 		AiServiceResponse metadata = new AiServiceResponse("metadata", null, null, null, null);
 		AiServiceResponse error = new AiServiceResponse("error", null, null, null, null);
 
-		// AI Client Mock
-		given(aiServiceClient.streamChat(any(), anyList()))
+		// AI Client Mock (chatId 매개변수 추가)
+		given(aiServiceClient.streamChat(any(), any(), anyList()))
 			.willReturn(Flux.just(delta, metadata, error));
 
 		// Handler Mock - 각 응답에 대해 적절한 SSE 반환 설정
@@ -227,7 +227,8 @@ class ChatServiceTest {
 		AiServiceResponse fakeMeta = new AiServiceResponse("metadata", null,
 			Map.of("token_usage", Map.of("total_cost_usd", "0.0055")), null, null);
 
-		when(aiServiceClient.streamChat(eq(request), anyList())).thenReturn(Flux.just(fakeDelta, fakeMeta));
+		// chatId 매개변수 추가
+		when(aiServiceClient.streamChat(eq(chatId), eq(request), anyList())).thenReturn(Flux.just(fakeDelta, fakeMeta));
 
 		// Handler가 Context를 업데이트 하도록 조작
 		when(chatStreamHandler.processAiResponse(any(), any())).thenAnswer(invocation -> {
@@ -252,6 +253,7 @@ class ChatServiceTest {
 
 		// Schedulers.boundedElastic()을 타고 비동기로 실행되므로 timeout으로 대기 후 검증
 		verify(chatWriter, timeout(1000).times(1)).saveChatData(any(ChatStreamContext.class));
-		verify(usageService, timeout(1000).times(1)).addMonthlyLlmUsage(any(BigDecimal.class));
+		// UsageService에
+		verify(usageService, timeout(1000).times(1)).addMonthlyLlmUsage( any(BigDecimal.class));
 	}
 }


### PR DESCRIPTION
## 📌 Summary
- AI 연동 클라이언트(`AiServiceClientImpl`) 로그에 세션 추적을 위한 `chatId` 및 히스토리 사이즈 추가

---

## 🎯 Background
- **로그 추적성(Traceability) 확보**: 기존 로그에는 식별자가 없어, 다중 사용자 접속 시 특정 지연이나 에러(예: 500 에러, 타임아웃)가 어떤 사용자의 세션에서 발생했는지 추적하기 불가능했습니다.
- **디버깅 효율화**: 장애 발생 시 해당 세션의 컨텍스트 크기(프롬프트 길이)가 원인인지 파악하기 위해 히스토리 개수를 함께 로깅할 필요가 있었습니다.

---

## 🔨 Changes
- `AiServiceClientImpl.streamChat` 메서드 시그니처에 `chatId` 파라미터 추가
- 스트리밍 첫 응답(TTFT) 수신 로그에 `ChatId` 포함
- 스트리밍 완료 로그에 `ChatId` 및 `HistorySize` 포함
- HTTP 통신 에러 및 예상치 못한 예외 발생 로그에 `ChatId` 포함

---

## 🧪 Test & Verification
- [x] 로컬 테스트 완료
- [x] 기존 기능 영향도 확인 (단순 로깅 파라미터 추가로 비즈니스 로직 영향 없음)

---

## ⚠️ Impact & Risk
- **영향 범위**: AI 챗봇 스트리밍 통신 구간의 모니터링 로그
- **리스크**: 핵심 비즈니스 로직(WebClient 스트리밍) 자체는 변경되지 않았으므로 런타임 기능 오류 리스크는 매우 낮음
- **롤백 방법**: 해당 커밋 Revert

---

## 📝 Notes

---

## 🔗 Related Issues
- Closes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 채팅 스트리밍 메서드에 채팅 ID 파라미터 추가로 세션 추적 기능 개선
  * 로깅에 채팅 식별자 포함되어 더 상세한 진단 정보 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->