### PR TITLE
Redis 연결 방식을 Cluster에서 Standalone으로 변경 및 SSL 적용

### DIFF
--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/global/config/RedisConfig.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/global/config/RedisConfig.java
@@ -37,7 +37,7 @@ public class RedisConfig {
 	@Bean
 	@Profile({"stg", "prod"})
 	public RedisConnectionFactory awsRedisConnectionFactory(
-		@Value("${REDIS_CLUSTER_NODES}") String redisHostString) {
+		@Value("${REDIS_HOST}") String redisHostString) {
 
 		String host = redisHostString;
 		int port = 6379;

--- a/chatbot/backend/src/main/java/com/hallachatbot/backend/global/config/RedisConfig.java
+++ b/chatbot/backend/src/main/java/com/hallachatbot/backend/global/config/RedisConfig.java
@@ -1,13 +1,9 @@
 package com.hallachatbot.backend.global.config;
 
-import java.time.Duration;
-import java.util.List;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-import org.springframework.data.redis.connection.RedisClusterConfiguration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
@@ -15,9 +11,6 @@ import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactor
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
-
-import io.lettuce.core.cluster.ClusterClientOptions;
-import io.lettuce.core.cluster.ClusterTopologyRefreshOptions;
 
 /**
  * <b>Redis (AWS ElastiCache 호환) 전역 설정 클래스</b>
@@ -32,43 +25,45 @@ import io.lettuce.core.cluster.ClusterTopologyRefreshOptions;
 public class RedisConfig {
 
 	/**
-	 * 운영 및 스테이징 환경용 Redis Cluster 커넥션 팩토리 빈을 생성.
+	 * 운영 및 스테이징 환경용 AWS Redis 커넥션 팩토리 빈을 생성.
 	 * <p>
 	 * <b>주요 설정 요소:</b>
 	 * <ul>
-	 * <li><b>Topology Refresh:</b> AWS ElastiCache(Valkey/Redis)의 노드 장애나 스케일 아웃 등으로 인한
-	 * Failover 발생 시, 애플리케이션 재시작 없이 클러스터 맵을 자동으로 갱신.</li>
-	 * <li><b>SSL 적용:</b> AWS 인프라의 '전송 중 암호화' 설정에 대응하기 위해 TLS 통신을 활성화.</li>
+	 * <li><b>Standalone 모드:</b> AWS ElastiCache 단일 연결 사용.</li>
+	 * <li><b>SSL 적용:</b> AWS 인프라의 '전송 중 암호화' 필수 설정에 대응하기 위해 TLS 통신을 활성화.</li>
 	 * </ul>
 	 * </p>
-	 *
-	 * @param clusterNodes 환경변수 또는 Parameter Store를 통해 주입받은 클러스터 구성 엔드포인트 목록
-	 * @return 자동 갱신 및 SSL 옵션이 적용된 {@link LettuceConnectionFactory} 객체
 	 */
 	@Bean
 	@Profile({"stg", "prod"})
-	public RedisConnectionFactory clusterRedisConnectionFactory(
-		@Value("${spring.data.redis.cluster.nodes}") List<String> clusterNodes) {
+	public RedisConnectionFactory awsRedisConnectionFactory(
+		@Value("${REDIS_CLUSTER_NODES}") String redisHostString) {
 
-		RedisClusterConfiguration clusterConfig = new RedisClusterConfiguration(clusterNodes);
+		String host = redisHostString;
+		int port = 6379;
 
-		// AWS 클러스터 노드 변경 시 자동으로 연결을 갱신
-		ClusterTopologyRefreshOptions refreshOptions = ClusterTopologyRefreshOptions.builder()
-			.enablePeriodicRefresh(Duration.ofMinutes(10))
-			.enableAllAdaptiveRefreshTriggers()
-			.build();
+		// 호스트/포트 분리
+		if (host.startsWith("rediss://")) {
+			host = host.substring(9);
+		} else if (host.startsWith("redis://")) {
+			host = host.substring(8);
+		}
 
-		ClusterClientOptions clientOptions = ClusterClientOptions.builder()
-			.topologyRefreshOptions(refreshOptions)
-			.build();
+		if (host.contains(":")) {
+			String[] parts = host.split(":");
+			host = parts[0];
+			port = Integer.parseInt(parts[1]);
+		}
 
-		// 클라이언트 설정에 Refresh Options와 SSL 보안 적용
+		// 단일 노드 설정 구성
+		RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(host, port);
+
+		// SSL 적용
 		LettuceClientConfiguration clientConfig = LettuceClientConfiguration.builder()
-			.clientOptions(clientOptions)
 			.useSsl()
 			.build();
 
-		return new LettuceConnectionFactory(clusterConfig, clientConfig);
+		return new LettuceConnectionFactory(config, clientConfig);
 	}
 
 	/**

--- a/chatbot/backend/src/main/resources/application-prod.yml
+++ b/chatbot/backend/src/main/resources/application-prod.yml
@@ -1,8 +1,7 @@
 spring:
   data:
     redis:
-      cluster:
-        nodes: ${REDIS_CLUSTER_NODES}
+      host: ${REDIS_HOST}
       ssl:
         enabled: true
   config:

--- a/chatbot/backend/src/main/resources/application-stg.yml
+++ b/chatbot/backend/src/main/resources/application-stg.yml
@@ -1,8 +1,7 @@
 spring:
   data:
     redis:
-      cluster:
-        nodes: ${REDIS_CLUSTER_NODES}
+      host: ${REDIS_HOST}
       ssl:
         enabled: true
   config:


### PR DESCRIPTION
## 📌 Summary
- AWS ElastiCache연결 실패로 인한 헬스체크 타임아웃 문제 해결

---

## 🎯 Background
- **이슈 사항**: ECS 배포 후 애플리케이션은 정상적으로 기동되었으나, Spring Boot Actuator의 헬스체크 과정에서 Redis 연결 실패가 발생하여 ALB가 서버를 `Unhealthy` 상태로 판단하는 문제가 있었음.
- **원인 파악**: 
  1. **모드 불일치**: 스프링 부트는 `RedisClusterConfiguration`을 통해 클러스터 모드로 접속을 시도했으나, 실제 AWS Valkey 인스턴스는 단일 노드(Master-Replica) 모드여서 `Cluster support disabled` 에러와 함께 연결이 거부됨.
  2. **SSL 설정 누락**: AWS ElastiCache의 '전송 중 암호화'가 필수로 설정되어 있으나, 기존 코드에는 TLS 통신 옵션이 빠져 있었음.

---

## 🔨 Changes
- **`RedisConfig.java` 전면 수정**
  - 운영/스테이징 프로파일(`stg`, `prod`)의 Redis 연결 설정을 `RedisClusterConfiguration`에서 `RedisStandaloneConfiguration`으로 변경했습니다.
  - `LettuceClientConfiguration.builder().useSsl().build()`를 추가하여 AWS의 필수 암호화 통신 요구사항을 충족시켰습니다.
  - 주소 값 문자열에 포함될 수 있는 `rediss://` 프로토콜과 포트 번호(`:6379`)를 동적으로 분리하여 안전하게 주입하도록 파싱 로직을 추가했습니다.

---

## 🧪 Test & Verification
- [x] 로컬 및 CI/CD 빌드 정상 통과
- [ ] ECS 환경 배포 후 `/actuator/health` 엔드포인트 정상 응답(200 OK) 확인
- [ ] AWS 콘솔 대상 그룹(Target Group) 상태 `Healthy` 전환 확인 완료

---

## 🔗 Related Issues
- Closes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 개선 사항

* **Chores**
  * Redis 연결을 클러스터에서 AWS 단일 인스턴스(환경 변수 REDIS_HOST 사용)로 전환했습니다.
  * SSL 기반의 단일 호스트 연결로 구성되어 프로덕션/스테이징 설정이 업데이트되었습니다.
  * 로컬 개발용 단독 Redis 설정은 비-스테이징/프로덕션 환경에서 유지됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->